### PR TITLE
UnifiedDiff: swallow trailing newlines

### DIFF
--- a/Language/UnifiedDiff.php
+++ b/Language/UnifiedDiff.php
@@ -43,8 +43,8 @@ class UnifiedDiff extends GreedyLanguage
                 ])),
             ],
             'diff' => [
-                'add'    => new Rule(new RegexMatcher('/^(?:^\+.*$)+/mi', [ 0 => Token::NAME ])),
-                'remove' => new Rule(new RegexMatcher('/^(?:^-.*$)+/mi', [ 0 => Token::NAME ])),
+                'add'    => new Rule(new RegexMatcher('/(?:^\+.*?(?>\R|$))+/mi', [ 0 => Token::NAME ])),
+                'remove' => new Rule(new RegexMatcher('/(?:^-.*?(?>\R|$))+/mi', [ 0 => Token::NAME ])),
             ],
         ]);
     }

--- a/Tests/Expected/Test/diff/symfony-forms.patch.tkn
+++ b/Tests/Expected/Test/diff/symfony-forms.patch.tkn
@@ -3,8 +3,8 @@ From: Sobak <msobaczewski@gmail.com>
 Date: Thu, 26 Mar 2020 12:44:41 +0100
 Subject: [PATCH] Absolute WIP
 
-{annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}---
- src/Controller/ImportController.php         | 10 ++++++++--{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
+{diff.remove:Kadet\Highlighter\Parser\Token\Token}---
+{/diff.remove:Kadet\Highlighter\Parser\Token\Token} src/Controller/ImportController.php         | 10 ++++++++--
  src/Form/ImportInitializeForm.php           |  2 +-
  src/Import/Importer/AbstractImporter.php    |  6 ++++++
  src/Import/Importer/AndroidCallImporter.php |  9 +++++++++
@@ -15,133 +15,133 @@ diff --git a/src/Controller/ImportController.php b/src/Controller/ImportControll
 index 53cdb95..5b5117c 100644
 {annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}--- a/src/Controller/ImportController.php{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
 {annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}+++ b/src/Controller/ImportController.php{/annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -22,6 +22,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -22,6 +22,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
  class ImportController extends AbstractController
  {
      private ContactRepository $contactRepository;
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    private ImportInitializeForm $importInitializeForm;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-     private ImporterRepository $importerRepository;
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+    private ImportInitializeForm $importInitializeForm;
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}     private ImporterRepository $importerRepository;
      private ImportWriter $importWriter;
      private MappingValidator $mappingValidator;
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -31,6 +32,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} class ImportController extends AbstractController{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -31,6 +32,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} class ImportController extends AbstractController{/comment:Kadet\Highlighter\Parser\Token\Token}
  
      public function __construct(
          ContactRepository $contactRepository,
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        ImportInitializeForm $importInitializeForm,{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-         ImporterRepository $importerRepository,
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+        ImportInitializeForm $importInitializeForm,
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}         ImporterRepository $importerRepository,
          ImportWriter $importWriter,
          MappingValidator $mappingValidator,
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -39,6 +41,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function __construct({/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -39,6 +41,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function __construct({/comment:Kadet\Highlighter\Parser\Token\Token}
          Environment $twig
      ) {
          $this->contactRepository = $contactRepository;
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $this->importInitializeForm = $importInitializeForm;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-         $this->importerRepository = $importerRepository;
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $this->importInitializeForm = $importInitializeForm;
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}         $this->importerRepository = $importerRepository;
          $this->importWriter = $importWriter;
          $this->mappingValidator = $mappingValidator;
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -58,7 +61,10 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function initialize(string $importerName){/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -58,7 +61,10 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function initialize(string $importerName){/comment:Kadet\Highlighter\Parser\Token\Token}
      {
          $importer = $this->importerRepository->get($importerName);
  
-{diff.remove:Kadet\Highlighter\Parser\Token\Token}-        $initializeForm = $this->createForm(ImportInitializeForm::class, null, [{/diff.remove:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $initializeFormBuilder = $this->createFormBuilder();{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $initializeFormBuilder = $importer->buildExtraForm($initializeFormBuilder);{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $initializeFormBuilder = $this->importInitializeForm->buildForm($initializeFormBuilder, [{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-             'action' => $this->generateUrl('import.mapping'),
+{diff.remove:Kadet\Highlighter\Parser\Token\Token}-        $initializeForm = $this->createForm(ImportInitializeForm::class, null, [
+{/diff.remove:Kadet\Highlighter\Parser\Token\Token}{diff.add:Kadet\Highlighter\Parser\Token\Token}+        $initializeFormBuilder = $this->createFormBuilder();
++
++        $initializeFormBuilder = $importer->buildExtraForm($initializeFormBuilder);
++        $initializeFormBuilder = $this->importInitializeForm->buildForm($initializeFormBuilder, [
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}             'action' => $this->generateUrl('import.mapping'),
              'file_extension' => $importer->getFileExtension() !== null ? '.' . $importer->getFileExtension() : null,
              'importer' => $importerName,
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -70,7 +76,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function initialize(string $importerName){/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -70,7 +76,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function initialize(string $importerName){/comment:Kadet\Highlighter\Parser\Token\Token}
          }
  
          return $this->render('import/initialize.html.twig', [
-{diff.remove:Kadet\Highlighter\Parser\Token\Token}-            'form' => $initializeForm->createView(),{/diff.remove:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+            'form' => $initializeFormBuilder->getForm()->createView(),{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-             'custom_instructions' => $customInstructions,
+{diff.remove:Kadet\Highlighter\Parser\Token\Token}-            'form' => $initializeForm->createView(),
+{/diff.remove:Kadet\Highlighter\Parser\Token\Token}{diff.add:Kadet\Highlighter\Parser\Token\Token}+            'form' => $initializeFormBuilder->getForm()->createView(),
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}             'custom_instructions' => $customInstructions,
              'importer' => $importer,
          ]);
 diff --git a/src/Form/ImportInitializeForm.php b/src/Form/ImportInitializeForm.php
 index d95f327..4ee4ec4 100644
 {annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}--- a/src/Form/ImportInitializeForm.php{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
 {annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}+++ b/src/Form/ImportInitializeForm.php{/annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -24,7 +24,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function __construct(UrlGeneratorInterface $urlGenerator){/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -24,7 +24,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function __construct(UrlGeneratorInterface $urlGenerator){/comment:Kadet\Highlighter\Parser\Token\Token}
  
      public function buildForm(FormBuilderInterface $builder, array $options)
      {
-{diff.remove:Kadet\Highlighter\Parser\Token\Token}-        $builder{/diff.remove:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        return $builder{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-             ->add('file', UploadType::class, [
+{diff.remove:Kadet\Highlighter\Parser\Token\Token}-        $builder
+{/diff.remove:Kadet\Highlighter\Parser\Token\Token}{diff.add:Kadet\Highlighter\Parser\Token\Token}+        return $builder
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}             ->add('file', UploadType::class, [
                  'constraints' => [
                      new NotBlank(),
 diff --git a/src/Import/Importer/AbstractImporter.php b/src/Import/Importer/AbstractImporter.php
 index 1df1a1f..092b863 100644
 {annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}--- a/src/Import/Importer/AbstractImporter.php{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
 {annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}+++ b/src/Import/Importer/AbstractImporter.php{/annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -9,6 +9,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -9,6 +9,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
  use App\Import\Dto\Contact;
  use App\Import\Dto\Link;
  use App\Import\Dto\Thread;
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\FormBuilderInterface;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
- use Symfony\Component\HttpFoundation\File\File;
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\FormBuilderInterface;
+{/diff.add:Kadet\Highlighter\Parser\Token\Token} use Symfony\Component\HttpFoundation\File\File;
  
  abstract class AbstractImporter
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -47,6 +48,11 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function addContact(Contact $contact): void{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -47,6 +48,11 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function addContact(Contact $contact): void{/comment:Kadet\Highlighter\Parser\Token\Token}
          $this->contacts[$contact->getId()] = $contact;
      }
  
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    {{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        return $formBuilder;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    }{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-     /** @return Asset[] */
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface
++    {
++        return $formBuilder;
++    }
++
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}     /** @return Asset[] */
      public function getAssets(): array
      {
 diff --git a/src/Import/Importer/AndroidCallImporter.php b/src/Import/Importer/AndroidCallImporter.php
 index 30d248f..2d5e714 100644
 {annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}--- a/src/Import/Importer/AndroidCallImporter.php{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
 {annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}+++ b/src/Import/Importer/AndroidCallImporter.php{/annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -8,6 +8,8 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -8,6 +8,8 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
  use App\Import\Dto\Message;
  use App\Import\Dto\Thread;
  use DateTime;
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\Extension\Core\Type\TextType;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\FormBuilderInterface;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
- use XMLReader;
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\Extension\Core\Type\TextType;
++use Symfony\Component\Form\FormBuilderInterface;
+{/diff.add:Kadet\Highlighter\Parser\Token\Token} use XMLReader;
  
  // @fixme don't hardcode prefix! keep that in options
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -29,6 +31,13 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function getIdentifier(): string{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -29,6 +31,13 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function getIdentifier(): string{/comment:Kadet\Highlighter\Parser\Token\Token}
          return 'android_calls';
      }
  
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    {{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        return $formBuilder{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+            ->add('prefix', TextType::class){/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+        ;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    }{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-     public function import(): void
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface
++    {
++        return $formBuilder
++            ->add('prefix', TextType::class)
++        ;
++    }
++
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}     public function import(): void
      {
          libxml_use_internal_errors(true);
 diff --git a/src/Import/Importer/ImporterInterface.php b/src/Import/Importer/ImporterInterface.php
 index 1b6199b..bc96aa0 100644
 {annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}--- a/src/Import/Importer/ImporterInterface.php{/annotation.diff.remove:Kadet\Highlighter\Parser\Token\Token}
 {annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}+++ b/src/Import/Importer/ImporterInterface.php{/annotation.diff.add:Kadet\Highlighter\Parser\Token\Token}
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -8,6 +8,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -8,6 +8,7 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token}{/comment:Kadet\Highlighter\Parser\Token\Token}
  use App\Import\Dto\Contact;
  use App\Import\Dto\Link;
  use App\Import\Dto\Thread;
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\FormBuilderInterface;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
- use Symfony\Component\HttpFoundation\File\File;
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+use Symfony\Component\Form\FormBuilderInterface;
+{/diff.add:Kadet\Highlighter\Parser\Token\Token} use Symfony\Component\HttpFoundation\File\File;
  
  interface ImporterInterface
-{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -20,6 +21,8 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function addLink(Link $link): void;{/comment:Kadet\Highlighter\Parser\Token\Token}
+{delimiter:Kadet\Highlighter\Parser\Token\Token}@@ -20,6 +21,8 @@{/delimiter:Kadet\Highlighter\Parser\Token\Token}{comment:Kadet\Highlighter\Parser\Token\Token} public function addLink(Link $link): void;{/comment:Kadet\Highlighter\Parser\Token\Token}
  
      public function addThread(Thread $thread): void;
  
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface;{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-{diff.add:Kadet\Highlighter\Parser\Token\Token}+{/diff.add:Kadet\Highlighter\Parser\Token\Token}
-     /** @return Asset[] */
+{diff.add:Kadet\Highlighter\Parser\Token\Token}+    public function buildExtraForm(FormBuilderInterface $formBuilder): FormBuilderInterface;
++
+{/diff.add:Kadet\Highlighter\Parser\Token\Token}     /** @return Asset[] */
      public function getAssets(): array;
  {/language.diff:Kadet\Highlighter\Parser\Token\LanguageToken}


### PR DESCRIPTION
This change fixes extra newlines being added after every `diff.add` and `diff.remove` token.

Before:
![image](https://user-images.githubusercontent.com/1347533/78413478-db12f700-7617-11ea-8381-da7ffeab7b39.png)

After:
![image](https://user-images.githubusercontent.com/1347533/78413507-f8e05c00-7617-11ea-8bad-84d79808e6cb.png)
