### PR TITLE
Fix benchmark:run command

### DIFF
--- a/bin/Commands/Benchmark/RunCommand.php
+++ b/bin/Commands/Benchmark/RunCommand.php
@@ -40,7 +40,7 @@ class RunCommand extends Command
             ), \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
-        $formatter = $input->hasOption('formatter')
+        $formatter = $input->getOption('formatter')
             ? KeyLighter::get()->getFormatter($input->getOption('formatter'))
             : KeyLighter::get()->getDefaultFormatter();
 
@@ -169,16 +169,24 @@ class RunCommand extends Command
 
     protected function geshi($source, $language)
     {
+        // Silence GeSHi notices
+        $previousErrorReporting = error_reporting(E_ALL ^ E_NOTICE);
+
         $geshi = microtime(true);
         geshi_highlight($source, $language, null, true);
-        return microtime(true) - $geshi;
+        $time = microtime(true) - $geshi;
+
+        // Restore previous error reporting level
+        error_reporting($previousErrorReporting);
+
+        return $time;
     }
 
     protected function output($results, InputInterface $input, OutputInterface $output)
     {
         $result = json_encode($results, $input->getOption('pretty') ? JSON_PRETTY_PRINT : 0);
 
-        if($input->hasArgument('output')) {
+        if($input->getArgument('output')) {
             file_put_contents($input->getArgument('output'), $result);
         } else {
             $output->write($result);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require-dev": {
     "symfony/console": "^2.8|^3.0",
     "phpunit/phpunit": "4.8.*",
-    "easybook/geshi": "v1.0.8.18"
+    "easybook/geshi": "v1.0.8.19"
   },
   "suggest": {
     "symfony/console": "Allows usage of keylighters CLI utility."

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "492b7234f66c247a837d5ebe3c169ece",
+    "content-hash": "b53ac267f954226c968078d6831f4ff9",
     "packages": [],
     "packages-dev": [
         {
@@ -63,20 +63,20 @@
         },
         {
             "name": "easybook/geshi",
-            "version": "v1.0.8.18",
+            "version": "v1.0.8.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/easybook/geshi.git",
-                "reference": "4b06bfe8c6fbedd6aad0a0700d650f591386e287"
+                "reference": "b4df5fa84a44d4e12eff67263a701eac7e157241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/easybook/geshi/zipball/4b06bfe8c6fbedd6aad0a0700d650f591386e287",
-                "reference": "4b06bfe8c6fbedd6aad0a0700d650f591386e287",
+                "url": "https://api.github.com/repos/easybook/geshi/zipball/b4df5fa84a44d4e12eff67263a701eac7e157241",
+                "reference": "b4df5fa84a44d4e12eff67263a701eac7e157241",
                 "shasum": ""
             },
             "require": {
-                "php": ">4.3.0"
+                "php": ">=5.0"
             },
             "type": "library",
             "autoload": {
@@ -105,7 +105,7 @@
                 "highlighter",
                 "syntax"
             ],
-            "time": "2016-10-05T07:15:42+00:00"
+            "time": "2018-04-20T18:19:44+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -690,6 +690,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -1409,5 +1410,6 @@
     "platform": {
         "php": ">=5.5.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
- Empty argument "output" is now supported
- Empty parameter "formatter" is now supported
- Notices generated by GeSHi are silenced
- GeSHi has been updated to patch version that no longer uses deprecated
  create_function()