### PR TITLE
Restore missing Create Issue button image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ report it via KeyLighter page: http://keylighter.kadet.net/.
 Submit code which is highlighted incorrectly, click **create issue**
 button and fill issue with more information.
 
-![buttton](https://dl.dropboxusercontent.com/u/60020102/ShareX/2016-06/2016-06-21_00-28-51-1c9.png)
+![buttton](https://i.imgur.com/0MEF9sc.png)
 
 In other case create issue via GitHub with template:
 ```md


### PR DESCRIPTION
I'm not sure if hosting that on imgur is any safer than Dropbox where it already got removed but here's my try. I thought about hosting that in the repository itself (e.g. in `Docs/assets/issue-button.png`) but I don't know whether your website allows that.

Perhaps the best option would be to simply host that on your own server but if you're ok with the result you can simply merge that solution :D

BTW: I used my registered imgur account, hopefully they don't delete this file too quickly.