### PR TITLE
Fix code style violations

### DIFF
--- a/Config/formatters.php
+++ b/Config/formatters.php
@@ -1,4 +1,6 @@
-<?php return [
+<?php
+
+return [
     'latex' => new \Kadet\Highlighter\Formatter\LatexFormatter(),
     'html'  => new \Kadet\Highlighter\Formatter\HtmlFormatter(),
     'lhtml' => new \Kadet\Highlighter\Formatter\HtmlFormatter(['lines' => ['enable' => true]]),

--- a/Exceptions/NameConflictException.php
+++ b/Exceptions/NameConflictException.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Exceptions;
-
 
 class NameConflictException extends \LogicException
 {

--- a/Exceptions/NoSuchElementException.php
+++ b/Exceptions/NoSuchElementException.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Exceptions;
-
 
 use Symfony\Component\Console\Exception\LogicException;
 

--- a/Formatter/AbstractFormatter.php
+++ b/Formatter/AbstractFormatter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Formatter;
-
 
 use Kadet\Highlighter\Parser\Token\Token;
 use Kadet\Highlighter\Parser\Tokens;
@@ -42,15 +40,15 @@ abstract class AbstractFormatter implements FormatterInterface
         }
         $result .= $this->_content(substr($source, $last));
 
-        return $result.($this->_options['lines']['enable'] ? $this->formatLineEnd($this->_line++) : '');
+        return $result . ($this->_options['lines']['enable'] ? $this->formatLineEnd($this->_line++) : '');
     }
 
     private function _content($text)
     {
         $content = $this->content($text);
 
-        return $this->_options['lines']['enable'] ? preg_replace_callback('/\R/u', function($feed) {
-            return $this->formatLineEnd($this->_line++).$feed[0].$this->formatLineStart($this->_line);
+        return $this->_options['lines']['enable'] ? preg_replace_callback('/\R/u', function ($feed) {
+            return $this->formatLineEnd($this->_line++) . $feed[0] . $this->formatLineStart($this->_line);
         }, $content) : $content;
     }
 

--- a/Formatter/CliFormatter.php
+++ b/Formatter/CliFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -35,7 +36,7 @@ class CliFormatter extends AbstractFormatter implements FormatterInterface
     public function __construct(array $options = [])
     {
         parent::__construct(array_replace_recursive([
-            'styles' => include __DIR__.'/../Styles/Cli/Default.php'
+            'styles' => include __DIR__ . '/../Styles/Cli/Default.php'
         ], $options));
 
         $this->_styles = $this->_options['styles'];
@@ -43,7 +44,7 @@ class CliFormatter extends AbstractFormatter implements FormatterInterface
 
     public function format(Tokens $tokens)
     {
-        return parent::format($tokens).Console::reset();
+        return parent::format($tokens) . Console::reset();
     }
 
     protected function token(Token $token)
@@ -61,7 +62,7 @@ class CliFormatter extends AbstractFormatter implements FormatterInterface
 
     protected function formatLineStart($line)
     {
-        return str_pad($line, 5, ' ', STR_PAD_LEFT) . ' | '.Console::set(Console::current());
+        return str_pad($line, 5, ' ', STR_PAD_LEFT) . ' | ' . Console::set(Console::current());
     }
 
     protected function formatLineEnd($line)

--- a/Formatter/DebugFormatter.php
+++ b/Formatter/DebugFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -36,7 +37,7 @@ class DebugFormatter extends CliFormatter implements FormatterInterface
      */
     public function __construct($styles = false)
     {
-        $this->_styles = $styles ?: include __DIR__.'/../Styles/Cli/Default.php';
+        $this->_styles = $styles ?: include __DIR__ . '/../Styles/Cli/Default.php';
     }
 
     public function format(Tokens $tokens, $leveled = true)
@@ -58,21 +59,22 @@ class DebugFormatter extends CliFormatter implements FormatterInterface
                 }
 
                 $result .=
-                    Console::styled(['color' => 'yellow'], 'Open  ').
-                    '['.$pos['line'].':'.$pos['pos'].'] '.
-                    Console::styled(['bold' => true], $token->name).' '.
-                    Console::styled(['color' => 'blue'], get_class($token)).' '.
-                    Console::styled(['color' => 'light green'], '('.(isset($token->rule->language) ? $token->rule->language->getIdentifier() : 'none').')').
+                    Console::styled(['color' => 'yellow'], 'Open  ') .
+                    '[' . $pos['line'] . ':' . $pos['pos'] . '] ' .
+                    Console::styled(['bold' => true], $token->name) . ' ' .
+                    Console::styled(['color' => 'blue'], get_class($token)) . ' ' .
+                    Console::styled(['color' => 'light green'], '(' . (isset($token->rule->language) ? $token->rule->language->getIdentifier() : 'none') . ')') .
                     PHP_EOL;
 
                 $level++;
 
-                $result .= Console::styled(self::getColor($token->name),
-                    ($leveled ? str_repeat('    ', $level) : null).
+                $result .= Console::styled(
+                    self::getColor($token->name),
+                    ($leveled ? str_repeat('    ', $level) : null) .
                     implode(
-                        PHP_EOL.($leveled ? str_repeat('    ', $level) : null),
+                        PHP_EOL . ($leveled ? str_repeat('    ', $level) : null),
                         explode(PHP_EOL, $this->escape(substr($source, $token->pos, $token->getLength())))
-                    ).
+                    ) .
                     PHP_EOL
                 );
             } else {
@@ -83,22 +85,23 @@ class DebugFormatter extends CliFormatter implements FormatterInterface
                 }
 
                 $result .=
-                    Console::styled(['color' => 'red'], 'Close ').
-                    '['.$pos['line'].':'.$pos['pos'].'] '.
-                    Console::styled(['bold' => true], $token->name).' '.
-                    Console::styled(['color' => 'blue'], get_class($token)).
+                    Console::styled(['color' => 'red'], 'Close ') .
+                    '[' . $pos['line'] . ':' . $pos['pos'] . '] ' .
+                    Console::styled(['bold' => true], $token->name) . ' ' .
+                    Console::styled(['color' => 'blue'], get_class($token)) .
                     PHP_EOL;
             }
 
             $last = $token->pos;
         }
-        $result .= $this->escape(substr($source, $last)).Console::reset();
+        $result .= $this->escape(substr($source, $last)) . Console::reset();
 
         return $result;
     }
 
-    private function escape($string) {
-        return str_replace(["\r", "\n"], ['\r', '\n'.PHP_EOL], $string);
+    private function escape($string)
+    {
+        return str_replace(["\r", "\n"], ['\r', '\n' . PHP_EOL], $string);
     }
 
     public function getColor($token)

--- a/Formatter/FormatterInterface.php
+++ b/Formatter/FormatterInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -58,7 +59,8 @@ class HtmlFormatter extends AbstractFormatter implements FormatterInterface
     {
         return sprintf(
             '<%s class="%s">',
-            $this->_tag, $this->_prefix.str_replace('.', " {$this->_prefix}", $token->name)
+            $this->_tag,
+            $this->_prefix . str_replace('.', " {$this->_prefix}", $token->name)
         );
     }
 

--- a/Formatter/LatexFormatter.php
+++ b/Formatter/LatexFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -36,7 +37,7 @@ class LatexFormatter extends AbstractFormatter implements FormatterInterface
     public function __construct(array $options = [])
     {
         parent::__construct(array_replace_recursive([
-            'styles' => include __DIR__.'/../Styles/Cli/Default.php'
+            'styles' => include __DIR__ . '/../Styles/Cli/Default.php'
         ], $options));
 
         $this->_styles = $this->_options['styles'];

--- a/Language/Apache.php
+++ b/Language/Apache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1
@@ -71,9 +72,8 @@ class Apache extends GreedyLanguage
             ]),
             'operator.punctuation' => new Rule(new RegexMatcher('/([\(\){},;])/i')),
             'keyword.format' => new Rule(
-                new RegexMatcher('/(%[\w%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'), [
-                    'context' => ['string']
-                ]
+                new RegexMatcher('/(%[\w%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'),
+                ['context' => ['string']]
             ),
         ]);
     }

--- a/Language/Assembler.php
+++ b/Language/Assembler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
@@ -38,9 +38,8 @@ class Assembler extends GreedyLanguage
             ]),
 
             'keyword.format' => new Rule(
-                new RegexMatcher('/(%[diuoxXfFeEgGaAcspn%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'), [
-                    'context' => ['string']
-                ]
+                new RegexMatcher('/(%[diuoxXfFeEgGaAcspn%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'),
+                ['context' => ['string']]
             ),
             'string' => CommonFeatures::strings(['single' => '\'', 'double' => '"'], [
                 'context' => ['!operator.escape', '!comment', '!string'],
@@ -48,14 +47,14 @@ class Assembler extends GreedyLanguage
 
             'symbol' => [
                 'type'  => new Rule(new WordMatcher(['byte', 'word', 'dword', 'qword']), ['name' => 'builtin']),
-                'label' => new Rule(new RegexMatcher('/([a-z]\w+:)/i'), ['priority'=>3])
+                'label' => new Rule(new RegexMatcher('/([a-z]\w+:)/i'), ['priority' => 3])
             ],
 
             'comment' => [
                 new Rule(new CommentMatcher([';'], []), ['priority' => 2])
             ],
 
-            'variable.register' => new Rule(new RegexMatcher('/\b('.implode('|', $this->registers).')\b/i')),
+            'variable.register' => new Rule(new RegexMatcher('/\b(' . implode('|', $this->registers) . ')\b/i')),
             'number' => new Rule(new RegexMatcher('/\b(-?[0-9][0-9a-fA-F]*[tTdDhHOoqQbByY]?)\b/i')),
             'operator' => [
                 'punctuation' => new Rule(new RegexMatcher('/(,)/'), ['priority' => 0]),

--- a/Language/C.php
+++ b/Language/C.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
@@ -65,9 +65,8 @@ class C extends GreedyLanguage
             ]),
 
             'keyword.format' => new Rule(
-                new RegexMatcher('/(%[diuoxXfFeEgGaAcspn%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'), [
-                    'context' => ['string']
-                ]
+                new RegexMatcher('/(%[diuoxXfFeEgGaAcspn%][-+#0]?(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?)/'),
+                ['context' => ['string']]
             ),
 
             'string' => array_merge([

--- a/Language/CSharp.php
+++ b/Language/CSharp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;

--- a/Language/Cobol.php
+++ b/Language/Cobol.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/CommonFeatures.php
+++ b/Language/CommonFeatures.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Language;
 
-
 use Kadet\Highlighter\Matcher\MatcherInterface;
 use Kadet\Highlighter\Matcher\SubStringMatcher;
 use Kadet\Highlighter\Parser\Rule;
@@ -24,11 +24,13 @@ use Kadet\Highlighter\Parser\TokenFactory;
 
 final class CommonFeatures
 {
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     public static function strings(array $strings, array $options = [])
     {
-        return array_map(function($matcher) use ($options) {
+        return array_map(function ($matcher) use ($options) {
             return new Rule(
                 $matcher instanceof MatcherInterface ? $matcher : new SubStringMatcher($matcher),
                 array_replace(['factory' => new TokenFactory(ContextualToken::class)], $options)

--- a/Language/Cpp.php
+++ b/Language/Cpp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;

--- a/Language/Css.php
+++ b/Language/Css.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -70,7 +71,7 @@ class Css extends GreedyLanguage
                 new CloseRule(new SubStringMatcher(')')),
             ],
 
-            'keyword.at-rule' => new Rule(new RegexMatcher('/(@(?:-[a-z]+-)?(?:'.implode('|', $at).'))/'), [
+            'keyword.at-rule' => new Rule(new RegexMatcher('/(@(?:-[a-z]+-)?(?:' . implode('|', $at) . '))/'), [
                 'priority' => 2
             ]),
 
@@ -132,7 +133,8 @@ class Css extends GreedyLanguage
         return 'css';
     }
 
-    protected function everywhere() {
+    protected function everywhere()
+    {
         static $validator;
         if (!$validator) {
             $validator = new Validator(['!string', '!comment']);

--- a/Language/Css/Less.php
+++ b/Language/Css/Less.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language\Css;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Parser\Rule;

--- a/Language/Css/PreProcessor.php
+++ b/Language/Css/PreProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language\Css;
-
 
 use Kadet\Highlighter\Language\Css;
 use Kadet\Highlighter\Matcher\CommentMatcher;
@@ -48,7 +48,8 @@ abstract class PreProcessor extends Css
         );
     }
 
-    protected function outside() {
+    protected function outside()
+    {
         return new Validator(['!symbol', '!string', '!number', '!comment', '!constant']);
     }
 }

--- a/Language/Css/Sass.php
+++ b/Language/Css/Sass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Css/Scss.php
+++ b/Language/Css/Scss.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Go.php
+++ b/Language/Go.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/GreedyLanguage.php
+++ b/Language/GreedyLanguage.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -93,12 +94,13 @@ abstract class GreedyLanguage extends Language
         return $this->_process($tokens);
     }
 
-    private function _process(TokenIterator $tokens) {
+    private function _process(TokenIterator $tokens)
+    {
         $context  = new Context($this);
         $result   = new Result($tokens->getSource(), $tokens->current());
 
         for ($tokens->next(); $tokens->valid(); $tokens->next()) {
-            if(!$tokens->current()->process($context, $this, $result, $tokens)) {
+            if (!$tokens->current()->process($context, $this, $result, $tokens)) {
                 break;
             }
         }
@@ -109,7 +111,9 @@ abstract class GreedyLanguage extends Language
     public function tokenize($source, $additional = [], $offset = 0, $embedded = false)
     {
         return new TokenIterator(
-            $this->_tokens($source, $offset, $additional, $embedded)->sort()->toArray(), $source, $offset
+            $this->_tokens($source, $offset, $additional, $embedded)->sort()->toArray(),
+            $source,
+            $offset
         );
     }
 
@@ -147,8 +151,8 @@ abstract class GreedyLanguage extends Language
     private function _rules($embedded = false)
     {
         $rules = clone $this->rules;
-        if(is_bool($embedded)) {
-            $rules->addMany(['language.'.$this->getIdentifier() => $this->getEnds($embedded)]);
+        if (is_bool($embedded)) {
+            $rules->addMany(['language.' . $this->getIdentifier() => $this->getEnds($embedded)]);
         }
 
         foreach ($rules->all() as $rule) {
@@ -173,7 +177,8 @@ abstract class GreedyLanguage extends Language
     public function getEnds($embedded = false)
     {
         return new Rule(
-            new WholeMatcher(), [
+            new WholeMatcher(),
+            [
                 'priority' => 10000,
                 'factory'  => new TokenFactory(LanguageToken::class),
                 'inject'   => $this,

--- a/Language/Haskell.php
+++ b/Language/Haskell.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Html.php
+++ b/Language/Html.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -33,7 +34,7 @@ class Html extends Xml
         $css = new Css();
         $js  = new JavaScript();
         $this->rules->addMany([
-            'language.'.$js->getIdentifier() => [
+            'language.' . $js->getIdentifier() => [
                 new OpenRule(new RegexMatcher('/<script.*?>()/'), [
                     'factory'     => new TokenFactory(LanguageToken::class),
                     'inject'      => $js,
@@ -45,7 +46,7 @@ class Html extends Xml
                     'language' => $js
                 ])
             ],
-            'language.'.$css->getIdentifier() => [
+            'language.' . $css->getIdentifier() => [
                 new OpenRule(new RegexMatcher('/<style.*?>()/'), [
                     'factory'     => new TokenFactory(LanguageToken::class),
                     'inject'      => $css,

--- a/Language/Http.php
+++ b/Language/Http.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -54,15 +55,15 @@ class Http extends GreedyLanguage
         $split = preg_split('/\R\R/', $source, 2);
 
         $http = $split[0];
-        if(isset($split[1]) && $payload = $split[1]) {
-            if(preg_match('/Content-Type: ([^;\r\n]*)/', $http, $matches)) {
+        if (isset($split[1]) && $payload = $split[1]) {
+            if (preg_match('/Content-Type: ([^;\r\n]*)/', $http, $matches)) {
                 $mime = $matches[1];
             } else {
                 $mime = 'text/plain';
             }
 
             $injected = self::byMime($mime);
-            $language = $this->_embeddedFactory->create('language.'.$injected->getIdentifier(), [
+            $language = $this->_embeddedFactory->create('language.' . $injected->getIdentifier(), [
                 'pos'    => strlen($source) - strlen($payload) + $offset,
                 'length' => strlen($payload),
                 'inject' => $injected,

--- a/Language/Ini.php
+++ b/Language/Ini.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Java.php
+++ b/Language/Java.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;

--- a/Language/JavaScript.php
+++ b/Language/JavaScript.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Language.php
+++ b/Language/Language.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -12,12 +13,12 @@
  *
  * From Kadet with love.
  */
+
 namespace Kadet\Highlighter\Language;
 
 use Kadet\Highlighter\KeyLighter;
 use Kadet\Highlighter\Parser\Rule;
 use Kadet\Highlighter\Parser\Tokens;
-
 
 /**
  * Class Language
@@ -87,10 +88,12 @@ abstract class Language
 
     public final function getFQN($class = false)
     {
-        $embedded =$this->getEmbedded();
-        return  ($class ? get_class($this) : $this->getIdentifier()).(
+        $embedded = $this->getEmbedded();
+        return  ($class ? get_class($this) : $this->getIdentifier()) . (
             !empty($embedded)
-                ? ' + '.implode(', ', array_map($class ? 'get_class' : function(Language $e) { return $e->getIdentifier(); }, $embedded))
+                ? ' + ' . implode(', ', array_map($class ? 'get_class' : function (Language $e) {
+                    return $e->getIdentifier();
+                }, $embedded))
                 : ''
         );
     }

--- a/Language/Latex.php
+++ b/Language/Latex.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Markdown.php
+++ b/Language/Markdown.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\KeyLighter;
 use Kadet\Highlighter\Matcher\DelegateRegexMatcher;
@@ -48,9 +48,8 @@ class Markdown extends Html
                 new Rule(new RegexMatcher('/^([^\r\n]+?)^(?:-+|=+)\R?$/m'))
             ],
             'format.italics'   => new Rule(
-                new RegexMatcher('/(?:^|[^*_])(?P<italics>(?P<i>[*_])(?>[^*_\r\n]|(?:(?P<b>[*_]{2})(?>[^*_\r\n]|(?&italics))*?\g{b}))+\g{i})/'), [
-                    'italics' => Token::NAME
-                ]
+                new RegexMatcher('/(?:^|[^*_])(?P<italics>(?P<i>[*_])(?>[^*_\r\n]|(?:(?P<b>[*_]{2})(?>[^*_\r\n]|(?&italics))*?\g{b}))+\g{i})/'),
+                ['italics' => Token::NAME]
             ),
             'format.bold'  => new Rule(
                 new RegexMatcher('/(?P<bold>(?P<b>\*\*|__)(?>[^*_\r\n]|(?:(?P<i>[*_]{2})(?>[^*_\r\n]|(?&bold))*?\g{i}))+\g{b})/', [
@@ -75,11 +74,12 @@ class Markdown extends Html
                 new Rule(
                     new DelegateRegexMatcher(
                         '/^```(.*?)\R(.*?)\R^```/ms',
-                        function($match, TokenFactoryInterface $factory) {
+                        function ($match, TokenFactoryInterface $factory) {
                             $lang = KeyLighter::get()->getLanguage($match[1][0]);
                             yield $factory->create(Token::NAME, ['pos' => $match[0][1], 'length' => strlen($match[0][0])]);
                             yield $factory->create(
-                                "language.{$lang->getIdentifier()}", [
+                                "language.{$lang->getIdentifier()}",
+                                [
                                     'pos'    => $match[2][1],
                                     'length' => strlen($match[2][0]),
                                     'inject' => $lang,
@@ -87,7 +87,8 @@ class Markdown extends Html
                                 ]
                             );
                         }
-                    ), [
+                    ),
+                    [
                         'context'     => Validator::everywhere(),
                         'postProcess' => true,
                         'priority'    => 1000

--- a/Language/Perl.php
+++ b/Language/Perl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
@@ -62,7 +62,8 @@ class Perl extends GreedyLanguage
                 new RegexMatcher('/<<\s*\'(\w+)\';(?P<string>.*?)\R\1/sm', [
                     'string' => Token::NAME,
                           0  => 'keyword.nowdoc'
-                ]), ['context' => ['!comment']]
+                ]),
+                ['context' => ['!comment']]
             ),
 
             'language.shell' => new Rule(new SubStringMatcher('`'), [

--- a/Language/Php.php
+++ b/Language/Php.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -67,12 +68,11 @@ class Php extends GreedyLanguage
                 new Rule(new RegexMatcher('/interface\s+([\w\\\]+)/i')),
                 new Rule(new DelegateRegexMatcher(
                     '/implements\s+((?:[\w\\\]+)(?:,\s*([\w\\\]+))+)/i',
-                    function($match, TokenFactoryInterface $factory) {
+                    function ($match, TokenFactoryInterface $factory) {
                         foreach (preg_split('/,\s*/', $match[1][0], 0, PREG_SPLIT_OFFSET_CAPTURE) as $interface) {
                             yield $factory->create(Token::NAME, [
                                 'pos' => $match[1][1] + $interface[1],
-                                'length' => strlen($interface[0])]
-                            );
+                                'length' => strlen($interface[0])]);
                         }
                     }
                 )),

--- a/Language/PlainText.php
+++ b/Language/PlainText.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -21,7 +22,9 @@ class PlainText extends GreedyLanguage
     /**
      * Tokenization rules
      */
-    public function setupRules() { }
+    public function setupRules()
+    {
+    }
 
     /** {@inheritdoc} */
     public function getIdentifier()

--- a/Language/PowerShell.php
+++ b/Language/PowerShell.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -43,17 +44,17 @@ class PowerShell extends GreedyLanguage
             ]),
 
             'variable' => [
-                new Rule(new RegexMatcher('/(?<!`)(\$'.$namespace.'[a-z_]\w*)/i', $namespaceGroup), [
+                new Rule(new RegexMatcher('/(?<!`)(\$' . $namespace . '[a-z_]\w*)/i', $namespaceGroup), [
                     'context'  => $variableRules,
                     'priority' => 0,
                 ]),
-                new Rule(new RegexMatcher('/[^`](\$\{'.$namespace.'.*?\})/i', $namespaceGroup), [
+                new Rule(new RegexMatcher('/[^`](\$\{' . $namespace . '.*?\})/i', $namespaceGroup), [
                     'context'  => $variableRules,
                     'priority' => 0,
                 ]),
             ],
 
-            'variable.splat' => new Rule(new RegexMatcher('/[^`](\@'.$namespace.'[a-z_]\w*)/i', $namespaceGroup), [
+            'variable.splat' => new Rule(new RegexMatcher('/[^`](\@' . $namespace . '[a-z_]\w*)/i', $namespaceGroup), [
                 'context'  => $variableRules,
                 'priority' => 0,
             ]),
@@ -85,10 +86,10 @@ class PowerShell extends GreedyLanguage
                 'Process', 'Return', 'Sequence', 'Switch', 'Throw', 'Trap', 'Try', 'Until', 'While', 'Workflow',
             ]), ['priority' => 3]),
 
-            'operator' => new Rule(new RegexMatcher('/(&|\-eq|\-ne|\-gt|\-ge|\-lt|\-le|\-ieq|\-ine|\-igt|\-ige|\-ilt|\-ile|\-ceq|\-cne|\-cgt|\-cge|\-clt|\-cle|\-like|\-notlike|\-match|\-notmatch|\-ilike|\-inotlike|\-imatch|\-inotmatch|\-clike|\-cnotlike|\-cmatch|\-cnotmatch|\-contains|\-notcontains|\-icontains|\-inotcontains|\-ccontains|\-cnotcontains|\-isnot|\-is|\-as|\-replace|\-ireplace|\-creplace|\-and|\-or|\-band|\-bor|\-not|\-bnot|\-f|\-casesensitive|\-exact|\-file|\-regex|\-wildcard)\b/i'),
-                [
-                    'context' => ['!string', '!comment'],
-                ]),
+            'operator' => new Rule(
+                new RegexMatcher('/(&|\-eq|\-ne|\-gt|\-ge|\-lt|\-le|\-ieq|\-ine|\-igt|\-ige|\-ilt|\-ile|\-ceq|\-cne|\-cgt|\-cge|\-clt|\-cle|\-like|\-notlike|\-match|\-notmatch|\-ilike|\-inotlike|\-imatch|\-inotmatch|\-clike|\-cnotlike|\-cmatch|\-cnotmatch|\-contains|\-notcontains|\-icontains|\-inotcontains|\-ccontains|\-cnotcontains|\-isnot|\-is|\-as|\-replace|\-ireplace|\-creplace|\-and|\-or|\-band|\-bor|\-not|\-bnot|\-f|\-casesensitive|\-exact|\-file|\-regex|\-wildcard)\b/i'),
+                ['context' => ['!string', '!comment']]
+            ),
 
             'symbol.parameter' => new Rule(new RegexMatcher('/\s(-\w+:?)\b/i'), [
                 'priority' => 0,

--- a/Language/Prolog.php
+++ b/Language/Prolog.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Python.php
+++ b/Language/Python.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
@@ -46,9 +46,8 @@ class Python extends GreedyLanguage
             ])),
 
             'operator' => new Rule(
-                new RegexMatcher('/([-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~])|\b(or|and|not)\b/'), [
-                    'priority' => -1
-                ]
+                new RegexMatcher('/([-+%=]=?|!=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~])|\b(or|and|not)\b/'),
+                ['priority' => -1]
             ),
 
             'expression' => new Rule(new RegexMatcher('/\{(\S+)\}/'), [

--- a/Language/Python/Django.php
+++ b/Language/Python/Django.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language\Python;
-
 
 use Kadet\Highlighter\Language\CommonFeatures;
 use Kadet\Highlighter\Language\GreedyLanguage;

--- a/Language/Ruby.php
+++ b/Language/Ruby.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/Shell.php
+++ b/Language/Shell.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/Sql.php
+++ b/Language/Sql.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Sql/MySql.php
+++ b/Language/Sql/MySql.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Twig.php
+++ b/Language/Twig.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Language\Python\Django;
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/TypeScript.php
+++ b/Language/TypeScript.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Parser\Rule;

--- a/Language/UnifiedDiff.php
+++ b/Language/UnifiedDiff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Language/Xaml.php
+++ b/Language/Xaml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Language;
-
 
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Parser\Rule;

--- a/Language/Xml.php
+++ b/Language/Xml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Matcher/CommentMatcher.php
+++ b/Matcher/CommentMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -49,7 +50,9 @@ class CommentMatcher implements MatcherInterface
         $all = [];
 
         foreach ($this->multiLine as $name => $comment) {
-            $comment = array_map(function ($e) { return preg_quote($e, '/'); }, $comment);
+            $comment = array_map(function ($e) {
+                return preg_quote($e, '/');
+            }, $comment);
 
             $all[] = [$name, "/({$comment[0]}(.*?){$comment[1]})/ms"];
         }
@@ -69,7 +72,8 @@ class CommentMatcher implements MatcherInterface
             if (preg_match_all($regex, $source, $matches, PREG_OFFSET_CAPTURE)) {
                 foreach ($matches[1] as $match) {
                     yield $factory->create(
-                        $name, ['pos' => $match[1], 'length' => strlen($match[0])]
+                        $name,
+                        ['pos' => $match[1], 'length' => strlen($match[0])]
                     );
                 }
             }

--- a/Matcher/DelegateRegexMatcher.php
+++ b/Matcher/DelegateRegexMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -49,7 +50,7 @@ class DelegateRegexMatcher implements MatcherInterface
 
         $callable = $this->callable;
         foreach ($matches as $match) {
-            foreach($callable($match, $factory) as $token) {
+            foreach ($callable($match, $factory) as $token) {
                 yield $token;
             }
         }

--- a/Matcher/MatcherInterface.php
+++ b/Matcher/MatcherInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Matcher/RegexMatcher.php
+++ b/Matcher/RegexMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Matcher/SubStringMatcher.php
+++ b/Matcher/SubStringMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Matcher/WholeMatcher.php
+++ b/Matcher/WholeMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Matcher/WordMatcher.php
+++ b/Matcher/WordMatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Parser/CloseRule.php
+++ b/Parser/CloseRule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Parser/Context.php
+++ b/Parser/Context.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Parser;
 
-
 use Kadet\Highlighter\Language\Language;
 use Kadet\Highlighter\Parser\Token\Token;
 
@@ -24,13 +24,15 @@ class Context
     public $stack = [];
     public $language;
 
-    public function __construct(Language $language = null) {
+    public function __construct(Language $language = null)
+    {
         $this->language = $language;
     }
 
-    public function find($needle) {
+    public function find($needle)
+    {
         foreach (array_reverse($this->stack, true) as $id => $name) {
-            if($name === $needle) {
+            if ($name === $needle) {
                 return $id;
             }
         }
@@ -48,11 +50,13 @@ class Context
         unset($this->stack[$token->id]);
     }
 
-    public function has($name) {
+    public function has($name)
+    {
         return in_array($name, $this->stack, true);
     }
 
-    public static function fromArray(array $array, Language $language = null) {
+    public static function fromArray(array $array, Language $language = null)
+    {
         $context = new Context($language);
         $context->stack = $array;
         return $context;

--- a/Parser/DelegateTokenFactory.php
+++ b/Parser/DelegateTokenFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Parser;
 
-
 use Kadet\Highlighter\Parser\Token\Token;
 
 class DelegateTokenFactory implements TokenFactoryInterface
@@ -29,7 +29,8 @@ class DelegateTokenFactory implements TokenFactoryInterface
      * @param callable (TokenFactoryInterface $factory, array $params) $function
      * @param TokenFactoryInterface|null                               $factory
      */
-    public function __construct(callable $function, TokenFactoryInterface $factory = null) {
+    public function __construct(callable $function, TokenFactoryInterface $factory = null)
+    {
         $this->_factory  = $factory ?: new TokenFactory(Token::class);
         $this->_callable = $function;
     }

--- a/Parser/OpenRule.php
+++ b/Parser/OpenRule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Parser/Result.php
+++ b/Parser/Result.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser;
-
 
 use Kadet\Highlighter\Parser\Token\Token;
 

--- a/Parser/Rule.php
+++ b/Parser/Rule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Parser/Rules.php
+++ b/Parser/Rules.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser;
-
 
 use Kadet\Highlighter\Exceptions\NameConflictException;
 use Kadet\Highlighter\Exceptions\NoSuchElementException;
@@ -171,7 +171,7 @@ class Rules extends \ArrayObject
             return;
         }
 
-        if(!isset($this[$type][$index])) {
+        if (!isset($this[$type][$index])) {
             throw new NoSuchElementException("There is no rule '$type' type indexed by '$index'.");
         }
 
@@ -186,7 +186,9 @@ class Rules extends \ArrayObject
     public function all()
     {
         $items = $this->getArrayCopy();
-        if(empty($items)) return [];
+        if (empty($items)) {
+            return [];
+        }
 
         return call_user_func_array('array_merge', $items);
     }

--- a/Parser/Token/ContextualToken.php
+++ b/Parser/Token/ContextualToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *1

--- a/Parser/Token/LanguageToken.php
+++ b/Parser/Token/LanguageToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -30,9 +31,10 @@ use Kadet\Highlighter\Parser\TokenIterator;
  */
 class LanguageToken extends Token
 {
-    public function __construct($name, $options = []) {
+    public function __construct($name, $options = [])
+    {
         parent::__construct($name, $options);
-        if(isset($options['inject'])) {
+        if (isset($options['inject'])) {
             $this->inject = $options['inject'];
         }
     }
@@ -75,7 +77,10 @@ class LanguageToken extends Token
         if ($this->_start->postProcess) {
             $source = substr($tokens->getSource(), $this->_start->pos - $tokens->getOffset(), $this->_start->getLength());
             $tokens = $this->_start->inject->tokenize(
-                $source, $result->getTokens(), $this->_start->pos, Language::EMBEDDED_BY_PARENT
+                $source,
+                $result->getTokens(),
+                $this->_start->pos,
+                Language::EMBEDDED_BY_PARENT
             );
             $result->exchangeArray($this->_start->inject->parse($tokens)->getTokens());
         }
@@ -90,6 +95,4 @@ class LanguageToken extends Token
         $result->append($this);
         return false;
     }
-
-
-} 
+}

--- a/Parser/Token/MetaToken.php
+++ b/Parser/Token/MetaToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Parser/Token/TerminatorToken.php
+++ b/Parser/Token/TerminatorToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser\Token;
-
 
 use Kadet\Highlighter\Language\Language;
 use Kadet\Highlighter\Parser\Context;
@@ -45,9 +45,11 @@ class TerminatorToken extends MetaToken
 
     protected function processEnd(Context $context, Language $language, Result $result, TokenIterator $tokens)
     {
-        foreach(array_filter($context->stack, function ($name) {
+        $closing = array_filter($context->stack, function ($name) {
             return in_array($name, $this->closes);
-        }) as $hash => $name) {
+        });
+
+        foreach ($closing as $hash => $name) {
             $end = new Token($name, ['pos' => $this->pos]);
             $tokens[$hash]->setEnd($end);
             $result->append($end);

--- a/Parser/Token/Token.php
+++ b/Parser/Token/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -81,7 +82,7 @@ class Token
         return $this->_end === null;
     }
 
-     public function isValid(Context $context)
+    public function isValid(Context $context)
     {
         if ($this->_valid === null) {
             $this->validate($context);
@@ -177,8 +178,9 @@ class Token
      *
      * @return bool Return true to continue processing, false to return already processed tokens.
      */
-    public function process(Context $context, Language $language, Result $result, TokenIterator $tokens) {
-        if(!$this->isValid($context)) {
+    public function process(Context $context, Language $language, Result $result, TokenIterator $tokens)
+    {
+        if (!$this->isValid($context)) {
             return true;
         }
 
@@ -187,15 +189,17 @@ class Token
             $this->processEnd($context, $language, $result, $tokens);
     }
 
-    protected function processStart(Context $context, Language $language, Result $result, TokenIterator $tokens) {
+    protected function processStart(Context $context, Language $language, Result $result, TokenIterator $tokens)
+    {
         $result->append($this);
         $context->push($this);
 
         return true;
     }
 
-    protected function processEnd(Context $context, Language $language, Result $result, TokenIterator $tokens) {
-        if($this->_start) {
+    protected function processEnd(Context $context, Language $language, Result $result, TokenIterator $tokens)
+    {
+        if ($this->_start) {
             $context->pop($this->_start);
         } else {
             if (($start = $context->find($this->name)) !== false) {
@@ -225,9 +229,9 @@ class Token
                 return $multiplier;
             }
         } elseif (($rule = Helper::cmp($b->rule->priority, $a->rule->priority)) !== 0) {
-            return $multiplier*$rule;
-        }  else {
-            return $multiplier*($a->id < $b->id ? -1 : 1);
+            return $multiplier * $rule;
+        } else {
+            return $multiplier * ($a->id < $b->id ? -1 : 1);
         }
     }
 }

--- a/Parser/TokenFactory.php
+++ b/Parser/TokenFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -66,30 +67,31 @@ class TokenFactory implements TokenFactoryInterface
         return $this->link($name, $params);
     }
 
-    private function link($name, $params) {
-        if($this->_type & Token::START) {
-            if(!isset($params['start'])) {
+    private function link($name, $params)
+    {
+        if ($this->_type & Token::START) {
+            if (!isset($params['start'])) {
                 $params['start'] = new $params['class']($name, $params);
             }
 
-            if($this->_type === Token::START) {
+            if ($this->_type === Token::START) {
                 $params['start']->setEnd(false);
                 return $params['start'];
             }
         }
 
-        if($this->_type & Token::END) {
+        if ($this->_type & Token::END) {
             if (isset($params['length'])) {
                 $end = $params;
                 $end['pos'] += $params['length'];
 
                 /** @var Token $end */
                 $params['end'] = new $params['class']($name, $end);
-            } elseif(!isset($params['end'])) {
+            } elseif (!isset($params['end'])) {
                 $params['end'] = new $params['class']($name, $params);
             }
 
-            if($this->_type === Token::END) {
+            if ($this->_type === Token::END) {
                 $params['end']->setStart(false);
                 return $params['end'];
             }

--- a/Parser/TokenFactoryInterface.php
+++ b/Parser/TokenFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -12,6 +13,7 @@
  *
  * From Kadet with love.
  */
+
 namespace Kadet\Highlighter\Parser;
 
 use Kadet\Highlighter\Parser\Token\Token;

--- a/Parser/TokenIterator.php
+++ b/Parser/TokenIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Parser/Tokens.php
+++ b/Parser/Tokens.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser;
-
 
 interface Tokens extends \Traversable
 {

--- a/Parser/UnprocessedTokens.php
+++ b/Parser/UnprocessedTokens.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -62,7 +63,7 @@ class UnprocessedTokens
         foreach (array_keys($this->_pending) as $position) {
             uasort(
                 $this->_tokens[$position],
-                Token::class.'::compare'
+                Token::class . '::compare'
             );
         }
         $this->_pending = [];

--- a/Parser/Validator/DelegateValidator.php
+++ b/Parser/Validator/DelegateValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser\Validator;
-
 
 use Kadet\Highlighter\Parser\Context;
 

--- a/Parser/Validator/Validator.php
+++ b/Parser/Validator/Validator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Parser\Validator;
-
 
 use Kadet\Highlighter\Parser\Context;
 
@@ -34,17 +34,19 @@ class Validator
      *
      * @param array $rules
      */
-    public function __construct(array $rules = []) {
+    public function __construct(array $rules = [])
+    {
         $this->setRules($rules);
     }
 
-    public function validate(Context $context, $additional = []) {
+    public function validate(Context $context, $additional = [])
+    {
         return $this->_validate($context->stack, $additional + $this->_rules);
     }
 
     public function setRules($rules)
     {
-        if(empty($rules)) {
+        if (empty($rules)) {
             $this->_rules = [ 'none' => Validator::CONTEXT_IN_ONE_OF ];
         } else {
             foreach ($rules as $key => $rule) {
@@ -57,20 +59,23 @@ class Validator
     private function _clean($rule, &$required)
     {
         if (strpos($rule, '.') !== false) {
-            foreach (array_filter(array_keys($required), function ($key) use ($rule) {
+            $parents = array_filter(array_keys($required), function ($key) use ($rule) {
                 return fnmatch($key . '.*', $rule);
-            }) as $remove) {
+            });
+
+            foreach ($parents as $remove) {
                 unset($required[$remove]);
             }
         }
     }
 
-    protected function _validate($context, $rules, $result = false) {
-        if(empty($context)) {
+    protected function _validate($context, $rules, $result = false)
+    {
+        if (empty($context)) {
             $context = ['none'];
         }
 
-        foreach($rules as $rule => &$type) {
+        foreach ($rules as $rule => &$type) {
             $matched = $this->_matches($context, $rule, $type);
 
             if ($type & Validator::CONTEXT_NOT_IN) {
@@ -123,30 +128,31 @@ class Validator
 
         $rule = substr($rule, $pos);
 
-        if($type & self::CONTEXT_REGEX) {
+        if ($type & self::CONTEXT_REGEX) {
             $rule = "/^$rule(\\.\\w+)?/i";
         }
 
         return [$rule, $type];
     }
 
-    private function _matches($context, $rule, $type) {
-        if($type & self::CONTEXT_EXACTLY) {
+    private function _matches($context, $rule, $type)
+    {
+        if ($type & self::CONTEXT_EXACTLY) {
             return in_array($rule, $context, true);
-        } elseif($type & self::CONTEXT_REGEX) {
-            foreach($context as $item) {
-                if(preg_match($rule, $item)) {
+        } elseif ($type & self::CONTEXT_REGEX) {
+            foreach ($context as $item) {
+                if (preg_match($rule, $item)) {
                     return true;
                 }
             }
             return false;
         } else {
-            if(in_array($rule, $context, true)) {
+            if (in_array($rule, $context, true)) {
                 return true;
             }
 
-            foreach($context as $item) {
-                if(fnmatch("$rule.*", $item)) {
+            foreach ($context as $item) {
+                if (fnmatch("$rule.*", $item)) {
                     return true;
                 }
             }

--- a/Styles/Cli/Default.php
+++ b/Styles/Cli/Default.php
@@ -1,4 +1,6 @@
-<?php return [
+<?php
+
+return [
     'string'       => ['color' => 'green'],
     'keyword'      => ['color' => 'yellow'],
     'operator'     => ['color' => 'yellow'],

--- a/Styles/Latex/Default.php
+++ b/Styles/Latex/Default.php
@@ -1,4 +1,6 @@
-<?php return [
+<?php
+
+return [
     'keyword'      => ['bold' => true],
     'variable'     => ['italic' => true],
     'comment'      => ['italic' => true],

--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/CliFormatterTest.php
+++ b/Tests/CliFormatterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -37,9 +38,9 @@ class CliFormatterTest extends TestCase
     public function testRendering()
     {
         $source   = 'abc + test';
-        $expected = Console::open(['color' => 'red']).'abc'.Console::close().' '.
-            Console::open(['color' => 'blue']).'+'.Console::close().' '.
-            Console::open(['color' => 'red']).'test'.Console::close().Console::reset();
+        $expected = Console::open(['color' => 'red']) . 'abc' . Console::close() . ' ' .
+            Console::open(['color' => 'blue']) . '+' . Console::close() . ' ' .
+            Console::open(['color' => 'red']) . 'test' . Console::close() . Console::reset();
 
         $first    = $this->_factory->create('token', ['pos' => 0, 'length' => 3]);
         $operator = $this->_factory->create('operator', ['pos' => 4, 'length' => 1]);
@@ -62,7 +63,7 @@ class CliFormatterTest extends TestCase
     public function testCallable()
     {
         $source   = 'abc';
-        $expected = Console::open(['color' => 'red']).'abc'.Console::close().Console::reset();
+        $expected = Console::open(['color' => 'red']) . 'abc' . Console::close() . Console::reset();
 
         $token    = $this->_factory->create('token', ['pos' => 0, 'length' => 3]);
 

--- a/Tests/ConsoleHelperTest.php
+++ b/Tests/ConsoleHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -29,7 +30,7 @@ class ConsoleHelperTest extends TestCase
     public function testStyled()
     {
         $console = new ConsoleHelper();
-        $this->assertEquals("\e[31mtest\033[0m", $console->styled(["color" =>"red"], "test"));
+        $this->assertEquals("\e[31mtest\033[0m", $console->styled(["color" => "red"], "test"));
     }
 
     public function testStacking()
@@ -37,10 +38,10 @@ class ConsoleHelperTest extends TestCase
         $console = new ConsoleHelper();
         $this->assertEquals(
             "\e[31mtest\e[32mtest2\e[0m\e[31mtest3\e[0m",
-            $console->open(["color" => "red"]).
-                "test".
-                    $console->open(["color" => "green"])."test2".$console->close().
-                "test3".
+            $console->open(["color" => "red"]) .
+                "test" .
+                    $console->open(["color" => "green"]) . "test2" . $console->close() .
+                "test3" .
             $console->close()
         );
     }

--- a/Tests/Constraint/TokensMatches.php
+++ b/Tests/Constraint/TokensMatches.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -104,7 +105,7 @@ class TokensMatches extends Constraint
 
     public function toString(): string
     {
-        return 'matches '.var_export($this->_tokens, true).' tokens';
+        return 'matches ' . var_export($this->_tokens, true) . ' tokens';
     }
 
     private function getTokens($tokens)

--- a/Tests/ContextTest.php
+++ b/Tests/ContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests;
-
 
 use Kadet\Highlighter\Language\Language;
 use Kadet\Highlighter\Parser\Context;
@@ -86,7 +86,8 @@ class ContextTest extends TestCase
         $this->assertFalse($context->find('foo'));
     }
     
-    public function getLanguageMock() {
+    public function getLanguageMock()
+    {
         return $this->getMockBuilder(Language::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -98,7 +99,8 @@ class ContextTest extends TestCase
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|Token
      */
-    public function getTokenMock($name, $params = []) {
+    public function getTokenMock($name, $params = [])
+    {
         return $this->getMockBuilder(Token::class)
             ->setConstructorArgs([$name, $params])
             ->getMock();

--- a/Tests/DelegateTokenFactoryTest.php
+++ b/Tests/DelegateTokenFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests;
-
 
 use Kadet\Highlighter\Parser\DelegateTokenFactory;
 use Kadet\Highlighter\Parser\Rule;
@@ -47,7 +47,8 @@ class DelegateTokenFactoryTest extends TestCase
         $child->expects($this->once())->method('setRule')->with($rule);
         $child->expects($this->once())->method('setType')->with(3);
 
-        $factory = new DelegateTokenFactory(function() {}, $child);
+        $factory = new DelegateTokenFactory(function () {
+        }, $child);
         $factory->setBase('token');
         $factory->setClass(Token::class);
         $factory->setRule($rule);

--- a/Tests/GreedyLanguageTest.php
+++ b/Tests/GreedyLanguageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,7 @@
 
 namespace Kadet\Highlighter\Tests;
 
-require_once __DIR__.'/MatcherTestCase.php';
+require_once __DIR__ . '/MatcherTestCase.php';
 require_once __DIR__ . '/Mocks/MockGreedyLanguage.php';
 
 use Kadet\Highlighter\KeyLighter;

--- a/Tests/HelperTest.php
+++ b/Tests/HelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Helpers/TestFormatter.php
+++ b/Tests/Helpers/TestFormatter.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\Tests\Helpers;
-
 
 use Kadet\Highlighter\Formatter\FormatterInterface;
 use Kadet\Highlighter\Parser\Token\Token;
@@ -29,7 +27,8 @@ class TestFormatter implements FormatterInterface
         return $result;
     }
 
-    private function getTokenInfo(Token $token) {
+    private function getTokenInfo(Token $token)
+    {
         return sprintf("%s:%s", $token->name, get_class($token));
     }
 }

--- a/Tests/HtmlFormatterTest.php
+++ b/Tests/HtmlFormatterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/KeyLighterTest.php
+++ b/Tests/KeyLighterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/LanguagesTest.php
+++ b/Tests/LanguagesTest.php
@@ -15,15 +15,17 @@ class LanguagesTest extends TestCase
     /** @var TestFormatter */
     protected $_formatter;
 
-    public function testFileProvider() {
-        $dir = realpath(__DIR__.'/Samples');
-        $out = realpath(__DIR__.'/Expected/Test');
+    public function testFileProvider()
+    {
+        $dir = realpath(__DIR__ . '/Samples');
+        $out = realpath(__DIR__ . '/Expected/Test');
 
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator(
                 $dir,
                 \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::UNIX_PATHS
-            ), \RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         /** @var \SplFileInfo $file */
@@ -46,7 +48,7 @@ class LanguagesTest extends TestCase
     {
         $source = file_get_contents($input);
 
-        if(!file_exists($expected)) {
+        if (!file_exists($expected)) {
             $this->markTestSkipped('File with expected tokens was not generated.');
         }
         $expected = file_get_contents($expected);

--- a/Tests/MatcherTestCase.php
+++ b/Tests/MatcherTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/CommentMatcherTest.php
+++ b/Tests/Matchers/CommentMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/DelegateRegexMatcherTest.php
+++ b/Tests/Matchers/DelegateRegexMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests\Matchers;
-
 
 use Kadet\Highlighter\Matcher\DelegateRegexMatcher;
 use Kadet\Highlighter\Tests\MatcherTestCase;

--- a/Tests/Matchers/RegexMatcherTest.php
+++ b/Tests/Matchers/RegexMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/SubStringMatcherTest.php
+++ b/Tests/Matchers/SubStringMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -31,7 +32,8 @@ class SubStringMatcherTest extends MatcherTestCase
                 ['end', 'pos' => 4],
                 ['start', 'pos' => 5],
                 ['end', 'pos' => 9],
-            ], $matcher->match($string, $this->getFactory())
+            ],
+            $matcher->match($string, $this->getFactory())
         );
     }
 }

--- a/Tests/Matchers/WholeMatcherTest.php
+++ b/Tests/Matchers/WholeMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/WordMatcherTest.php
+++ b/Tests/Matchers/WordMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Mocks/MockGreedyLanguage.php
+++ b/Tests/Mocks/MockGreedyLanguage.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/RuleTest.php
+++ b/Tests/RuleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -65,35 +66,42 @@ class RuleTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testThrowsOnWrongValidator() {
+    public function testThrowsOnWrongValidator()
+    {
         new Rule(null, [
             'context' => 'nope'
         ]);
     }
 
-    public function testAcceptsCallableAsContext() {
+    public function testAcceptsCallableAsContext()
+    {
         $rule = new Rule(null, [
-            'context' => function() { return true; }
+            'context' => function () {
+                return true;
+            }
         ]);
 
         $this->assertInstanceOf(DelegateValidator::class, $rule->validator);
     }
 
-    public function testDisable() {
+    public function testDisable()
+    {
         $rule = new Rule(new WholeMatcher());
 
         $rule->disable();
         $this->assertEmpty($rule->match('source'));
     }
 
-    public function testEnable() {
+    public function testEnable()
+    {
         $rule = new Rule(new WholeMatcher(), ['enabled' => false]);
 
         $rule->enable();
         $this->assertNotEmpty($rule->match('source'));
     }
 
-    public function testMatcherReturning() {
+    public function testMatcherReturning()
+    {
         $matcher = $this->createMock(MatcherInterface::class);
 
         $rule = new Rule($matcher);

--- a/Tests/RulesTest.php
+++ b/Tests/RulesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Tests;
 
-
 use Kadet\Highlighter\Language\GreedyLanguage;
 use Kadet\Highlighter\Language\Language;
 use Kadet\Highlighter\Parser\Rule;
@@ -29,7 +29,7 @@ class RulesTest extends TestCase
         $rule = new Rule();
 
         $rules = new Rules($this->getLanguageMock());
-        $rules->add('test',  $rule);
+        $rules->add('test', $rule);
         $rules->add('token', $rule);
 
         $this->assertContains($rule, $rules->all());
@@ -41,7 +41,7 @@ class RulesTest extends TestCase
         $rule = new Rule(null, ['name' => 'name']);
 
         $rules = new Rules($this->getLanguageMock());
-        $rules->add('test',  $rule);
+        $rules->add('test', $rule);
 
         $this->assertSame($rule, $rules->rule('test', 'name'));
     }
@@ -116,13 +116,15 @@ class RulesTest extends TestCase
     }
 
     /** @expectedException \Kadet\Highlighter\Exceptions\NoSuchElementException */
-    public function testUndefinedRule() {
+    public function testUndefinedRule()
+    {
         $rules = new Rules($this->getLanguageMock());
         $rules->rules('nope');
     }
 
     /** @expectedException \LogicException */
-    public function testWrongFormat() {
+    public function testWrongFormat()
+    {
         $rules = new Rules($this->getLanguageMock());
         $rules->addMany([
             'token' => "string",
@@ -159,7 +161,7 @@ class RulesTest extends TestCase
         $replacement = new Rule();
 
         $rules = new Rules($this->getLanguageMock());
-        $rules->add('test',  $original);
+        $rules->add('test', $original);
         $this->assertSame($original, $rules->rule('test'));
 
         $rules->replace($replacement, 'test');
@@ -169,7 +171,8 @@ class RulesTest extends TestCase
     /**
      * @return Language
      */
-    private function getLanguageMock() {
+    private function getLanguageMock()
+    {
         return $this->getMockBuilder(GreedyLanguage::class)->disableOriginalConstructor()->getMock();
     }
 }

--- a/Tests/StringHelperTest.php
+++ b/Tests/StringHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -22,7 +23,7 @@ class StringHelperTest extends TestCase
 {
     public function testConvertingOffsetToLineAndColumn()
     {
-        $source = "test".PHP_EOL."test2";
+        $source = "test" . PHP_EOL . "test2";
 
         $this->assertEquals(['line' => 2, 'pos' => 2], StringHelper::positionToLine($source, 4 + strlen(PHP_EOL) + 1));
     }

--- a/Tests/TokenFactoryTest.php
+++ b/Tests/TokenFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/TokenIteratorTest.php
+++ b/Tests/TokenIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/TokenListTest.php
+++ b/Tests/TokenListTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -51,15 +52,18 @@ class TokenListTest extends TestCase
     {
         $tokens    = [];
         $tokens[0] = $token = $this->_factory->create(
-            'token.1', ['pos' => 2, 'length' => 3, 'rule' => new Rule(null, ['priority' => 3])]
+            'token.1',
+            ['pos' => 2, 'length' => 3, 'rule' => new Rule(null, ['priority' => 3])]
         );
         $tokens[1] = $token->getEnd();
         $tokens[2] = $token = $this->_factory->create(
-            'token.2', ['pos' => 2, 'length' => 3, 'rule' => new Rule(null, ['priority' => 1])]
+            'token.2',
+            ['pos' => 2, 'length' => 3, 'rule' => new Rule(null, ['priority' => 1])]
         );
         $tokens[3] = $token->getEnd();
         $tokens[4] = $token = $this->_factory->create(
-            'token.3', ['pos' => 2, 'length' => 4, 'rule' => new Rule(null, ['priority' => 2])]
+            'token.3',
+            ['pos' => 2, 'length' => 4, 'rule' => new Rule(null, ['priority' => 2])]
         );
         $tokens[5] = $token->getEnd();
 

--- a/Tests/Tokens/ContextualTokenTest.php
+++ b/Tests/Tokens/ContextualTokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/LanguageTokenTest.php
+++ b/Tests/Tokens/LanguageTokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests\Tokens;
-
 
 use Kadet\Highlighter\Parser\Token\LanguageToken;
 

--- a/Tests/Tokens/MetaTokenTest.php
+++ b/Tests/Tokens/MetaTokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests\Tokens;
-
 
 use Kadet\Highlighter\Parser\Token\MetaToken;
 use Kadet\Highlighter\Parser\TokenIterator;

--- a/Tests/Tokens/TerminatorTokenTest.php
+++ b/Tests/Tokens/TerminatorTokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests\Tokens;
-
 
 use Kadet\Highlighter\Parser\Rule;
 use Kadet\Highlighter\Parser\Token\TerminatorToken;

--- a/Tests/Tokens/TokenComparisonTest.php
+++ b/Tests/Tokens/TokenComparisonTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Tests\Tokens;
 
-
 use Kadet\Highlighter\Parser\Token\Token;
 use PHPUnit\Framework\TestCase;
 
@@ -29,6 +29,6 @@ class TokenComparisonTest extends TestCase
         $start->setEnd($end);
 
         $this->assertEquals(-1, Token::compare($start, $end));
-        $this->assertEquals( 1, Token::compare($end, $start));
+        $this->assertEquals(1, Token::compare($end, $start));
     }
 }

--- a/Tests/Tokens/TokenTest.php
+++ b/Tests/Tokens/TokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -110,14 +111,17 @@ class TokenTest extends TokenTestCase
         $validator->expects($this->once())->method('validate')->with($context, []);
 
         $token = $this->_factory->create(
-            'test.name', [
+            'test.name',
+            [
                 'pos'    => 15,
                 'length' => 10,
                 'rule'   => new Rule(
-                    null, [
-                    'language' => $language,
-                    'context'  => $validator
-                ])
+                    null,
+                    [
+                        'language' => $language,
+                        'context'  => $validator,
+                    ]
+                )
             ]
         );
         $token->isValid($context);

--- a/Tests/Tokens/TokenTestCase.php
+++ b/Tests/Tokens/TokenTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\Tests\Tokens;
-
 
 use Kadet\Highlighter\Language\Language;
 use Kadet\Highlighter\Parser\Context;

--- a/Tests/ValidatorTest.php
+++ b/Tests/ValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -15,7 +16,6 @@
 
 namespace Kadet\Highlighter\Tests;
 
-
 use Kadet\Highlighter\Parser\Context;
 use Kadet\Highlighter\Parser\Validator\DelegateValidator;
 use Kadet\Highlighter\Parser\Validator\Validator;
@@ -23,7 +23,8 @@ use PHPUnit\Framework\TestCase;
 
 class ValidatorTest extends TestCase
 {
-    public function testInValidation() {
+    public function testInValidation()
+    {
         $validator = new Validator(['test']);
         
         $this->assertTrue($validator->validate(Context::fromArray(['test'])));
@@ -32,7 +33,8 @@ class ValidatorTest extends TestCase
         $this->assertFalse($validator->validate(Context::fromArray(['smth'])));
     }
 
-    public function testNotInValidation() {
+    public function testNotInValidation()
+    {
         $validator = new Validator(['!test']);
 
         $this->assertFalse($validator->validate(Context::fromArray(['test'])));

--- a/bin/Application.php
+++ b/bin/Application.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin;
-
 
 use Kadet\Highlighter\bin\Commands\Benchmark;
 use Kadet\Highlighter\bin\Commands\Dev;
@@ -37,7 +37,7 @@ class Application extends SymfonyApplication
     protected function getCommandName(InputInterface $input)
     {
         $command = $input->getFirstArgument();
-        if(!$command && !$input->hasParameterOption('--help')) {
+        if (!$command && !$input->hasParameterOption('--help')) {
             return 'list';
         } elseif ($this->has($command)) {
             return $command;
@@ -49,12 +49,10 @@ class Application extends SymfonyApplication
 
     protected function getDefaultCommands()
     {
-
         $devcommands = class_exists(TestFormatter::class) ? [
             new Dev\GenerateTableCommand(),
             new Dev\GenerateMetadataCommand(),
             new Benchmark\RunCommand(),
-//            new Benchmark\ReportCommand(),
             new Benchmark\AnalyzeCommand(),
             new Commands\Test\RegenerateCommand()
         ] : [];
@@ -95,6 +93,4 @@ class Application extends SymfonyApplication
 
         return parent::run($input, $output);
     }
-
-
 }

--- a/bin/Commands/Benchmark/AnalyzeCommand.php
+++ b/bin/Commands/Benchmark/AnalyzeCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands\Benchmark;
-
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -38,7 +38,9 @@ class AnalyzeCommand extends Command
 
         $output->writeln(sprintf(
             "Date: <info>%s</info> Formatter: <info>%s</info>, Comment: <info>%s</info>",
-            date('d.m.Y H:i:s', $json['timestamp']), $json['formatter'], isset($json['comment']) ? $json['comment'] : 'none'
+            date('d.m.Y H:i:s', $json['timestamp']),
+            $json['formatter'],
+            isset($json['comment']) ? $json['comment'] : 'none'
         ));
 
         $table = new Table($output);
@@ -66,7 +68,7 @@ class AnalyzeCommand extends Command
 
             foreach ($data['memory'] as $set => $memory) {
                 $result = array_map(function ($memory) use ($data, $input) {
-                    $bytes = $input->getOption('relative') ? $memory/$data['size'] : $memory;
+                    $bytes = $input->getOption('relative') ? $memory / $data['size'] : $memory;
                     return $this->formatBytes($bytes, (bool)$input->getOption('relative'));
                 }, $memory);
 
@@ -74,16 +76,16 @@ class AnalyzeCommand extends Command
             }
         }
 
-        if(!$input->hasParameterOption('--summary')) {
+        if (!$input->hasParameterOption('--summary')) {
             $table->render();
         }
 
-        $summary = array_filter($summary, function($key) use ($input) {
+        $summary = array_filter($summary, function ($key) use ($input) {
             return fnmatch($input->getOption('summary') ?: '*', $key);
         }, ARRAY_FILTER_USE_KEY);
 
         $max = max(array_map('strlen', array_keys($summary)));
-        foreach($summary as $name => $set) {
+        foreach ($summary as $name => $set) {
             $output->writeln(sprintf(
                 "<comment>%s</comment> %s %s",
                 str_pad($name, $max, ' ', STR_PAD_LEFT),
@@ -137,7 +139,8 @@ class AnalyzeCommand extends Command
         }, $result)) / count($result));
     }
 
-    function formatBytes($bytes, $relative = false) {
+    private function formatBytes($bytes, $relative = false)
+    {
         $units = array('B', 'KB', 'MB', 'GB', 'TB');
 
         $bytes = max($bytes, 0);

--- a/bin/Commands/Benchmark/RunCommand.php
+++ b/bin/Commands/Benchmark/RunCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands\Benchmark;
-
 
 use Kadet\Highlighter\Formatter\FormatterInterface;
 use Kadet\Highlighter\KeyLighter;
@@ -32,12 +32,13 @@ class RunCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dir = __DIR__.static::DIRECTORY;
+        $dir = __DIR__ . static::DIRECTORY;
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator(
                 $dir,
                 \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::UNIX_PATHS
-            ), \RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         $formatter = $input->getOption('formatter')
@@ -61,7 +62,9 @@ class RunCommand extends Command
 
             $output->writeln(sprintf(
                 'File: <info>%s</info> Size: <info>%s</info> Language: <info>%s</info>',
-                substr($file->getPathname(), strlen($dir)), $file->getSize(), get_class($language)
+                substr($file->getPathname(), strlen($dir)),
+                $file->getSize(),
+                get_class($language)
             ), OutputInterface::VERBOSITY_VERBOSE);
 
             // Dry run, to include all necessary files.
@@ -70,13 +73,13 @@ class RunCommand extends Command
             $times  = [];
             $memory = [];
 
-            for($i = $input->getOption('times'), $progress = new ProgressBar($output, $i); $i > 0; $i--) {
+            for ($i = $input->getOption('times'), $progress = new ProgressBar($output, $i); $i > 0; $i--) {
                 $progress->display();
                 $result = $this->benchmark($source, $language, $formatter);
-                $times  = array_merge_recursive($times,  $result['times']);
+                $times  = array_merge_recursive($times, $result['times']);
                 $memory = array_merge_recursive($memory, $result['memory']);
 
-                if($input->getOption('geshi') && class_exists('GeSHi')) {
+                if ($input->getOption('geshi') && class_exists('GeSHi')) {
                     $times['geshi'][] = $this->geshi($source, $file->getExtension());
                 }
 
@@ -121,17 +124,17 @@ class RunCommand extends Command
         gc_collect_cycles(); // force garbage collector
         $memory = $this->getMemory();
 
-        $tokenization = $this->_benchmark(function() use ($language, $source) {
+        $tokenization = $this->_benchmark(function () use ($language, $source) {
             return $language->tokenize($source);
         });
         $tokens = $tokenization['result'];
 
-        $parsing = $this->_benchmark(function() use ($language, $tokens) {
+        $parsing = $this->_benchmark(function () use ($language, $tokens) {
             return $language->parse($tokens);
         });
         $parsed = $tokenization['result'];
 
-        $formatting = $this->_benchmark(function() use ($formatter, $parsed) {
+        $formatting = $this->_benchmark(function () use ($formatter, $parsed) {
             return $formatter->format($parsed);
         });
 
@@ -191,7 +194,7 @@ class RunCommand extends Command
          */
         $result = json_encode($results, $input->getOption('pretty') ? JSON_PRETTY_PRINT : 0);
 
-        if($input->getArgument('output')) {
+        if ($input->getArgument('output')) {
             file_put_contents($input->getArgument('output'), $result);
         } else {
             $output->write($result);

--- a/bin/Commands/Dev/GenerateMetadataCommand.php
+++ b/bin/Commands/Dev/GenerateMetadataCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands\Dev;
-
 
 use Kadet\Highlighter\Language\Language;
 use Symfony\Component\Console\Command\Command;
@@ -34,12 +34,12 @@ class GenerateMetadataCommand extends Command
             return 1;
         }
 
-        if($input->getOption('dry')) {
+        if ($input->getOption('dry')) {
             $output->writeln($this->generate($output));
         } else {
             file_put_contents(
                 __DIR__ . '/../../../Config/metadata.php',
-                "<?php\n\nreturn ".$this->generate($output).";\n"
+                "<?php\n\nreturn " . $this->generate($output) . ";\n"
             );
         }
 
@@ -57,7 +57,7 @@ class GenerateMetadataCommand extends Command
 
     protected function generate(OutputInterface $output)
     {
-        $dir = __DIR__ . '/../../../Language'.DIRECTORY_SEPARATOR;
+        $dir = __DIR__ . '/../../../Language' . DIRECTORY_SEPARATOR;
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
             \RecursiveIteratorIterator::LEAVES_ONLY
@@ -72,11 +72,12 @@ class GenerateMetadataCommand extends Command
 
             $output->writeln(sprintf(
                 'Found <info>%s</info>, assuming class <language>%s</language>',
-                $file->getBasename(), $class
+                $file->getBasename(),
+                $class
             ), OutputInterface::VERBOSITY_VERBOSE);
 
 
-            if($metadata = $this->process($output, $class)) {
+            if ($metadata = $this->process($output, $class)) {
                 $result[] = $metadata;
             }
         }

--- a/bin/Commands/Dev/GenerateTableCommand.php
+++ b/bin/Commands/Dev/GenerateTableCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -16,7 +17,6 @@
 
 namespace Kadet\Highlighter\bin\Commands\Dev;
 
-
 use Kadet\Highlighter\KeyLighter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,7 +27,7 @@ class GenerateTableCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if($input->getOption('dry')) {
+        if ($input->getOption('dry')) {
             $output->writeln($this->generate());
         } else {
             $path = __DIR__ . '/../../../Docs/A-languages.md';
@@ -36,7 +36,7 @@ class GenerateTableCommand extends Command
             $content = file_get_contents($path);
             file_put_contents($path, preg_replace(
                 '/^<!-- aliasbegin -->\R.*?^<!-- aliasend -->\R/ms',
-                "<!-- aliasbegin -->\n".$this->generate()."<!-- aliasend -->\n",
+                "<!-- aliasbegin -->\n" . $this->generate() . "<!-- aliasend -->\n",
                 $content
             ));
             $output->writeln("<info>Closing file ./Docs/A-languages.md ...</info>", OutputInterface::VERBOSITY_VERBOSE);
@@ -55,8 +55,8 @@ class GenerateTableCommand extends Command
     protected function generate()
     {
         $result = [];
-        foreach(['name', 'mime', 'extension'] as $what) {
-            foreach(KeyLighter::get()->registeredLanguages($what, true) as $name => $class) {
+        foreach (['name', 'mime', 'extension'] as $what) {
+            foreach (KeyLighter::get()->registeredLanguages($what, true) as $name => $class) {
                 $result[$class][$what][] = $name;
             }
         }
@@ -65,11 +65,11 @@ class GenerateTableCommand extends Command
 
         $return  =  "Class | Name | MIME | Extension\n";
         $return .=  "------|------|------|----------\n";
-        foreach($result as $class => $aliases) {
-            $return .= '`'.$class.'` | ';
-            $return .= (isset($aliases['name']) ? '`'.implode('`, `', $aliases['name']).'`' : 'none').' | ';
-            $return .= (isset($aliases['mime']) ? '`'.implode('`, `', $aliases['mime']).'`' : 'none').' | ';
-            $return .= (isset($aliases['extension']) ? '`'.implode('`, `', $aliases['extension']).'`' : 'none'). "\n";
+        foreach ($result as $class => $aliases) {
+            $return .= '`' . $class . '` | ';
+            $return .= (isset($aliases['name']) ? '`' . implode('`, `', $aliases['name']) . '`' : 'none') . ' | ';
+            $return .= (isset($aliases['mime']) ? '`' . implode('`, `', $aliases['mime']) . '`' : 'none') . ' | ';
+            $return .= (isset($aliases['extension']) ? '`' . implode('`, `', $aliases['extension']) . '`' : 'none') . "\n";
         }
 
         return $return;

--- a/bin/Commands/FormattersCommand.php
+++ b/bin/Commands/FormattersCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands;
-
 
 use Kadet\Highlighter\KeyLighter;
 use Symfony\Component\Console\Command\Command;
@@ -40,11 +40,11 @@ class FormattersCommand extends Command
         $formatters = KeyLighter::get()->registeredFormatters();
         $table = new Table($output);
 
-        if(!$input->getOption('headerless')) {
+        if (!$input->getOption('headerless')) {
             $table->setHeaders(['Name', 'Formatter']);
         }
 
-        $table->setRows(array_map(function($alias, $class) {
+        $table->setRows(array_map(function ($alias, $class) {
             return [
                 "<comment>{$alias}</comment>",
                 get_class($class)

--- a/bin/Commands/HighlightCommand.php
+++ b/bin/Commands/HighlightCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands;
-
 
 use Kadet\Highlighter\bin\VerboseOutput;
 use Kadet\Highlighter\KeyLighter;
@@ -36,12 +36,16 @@ class HighlightCommand extends Command
     {
         $this->setName('highlight')
             ->addArgument('path', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'File(s) to highlight')
-            ->addOption('normalize',  null, InputOption::VALUE_OPTIONAL, 'Normalize input to LF')
+            ->addOption('normalize', null, InputOption::VALUE_OPTIONAL, 'Normalize input to LF')
             ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'Source Language to highlight, see <comment>list-languages</comment> command')
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format, see <comment>list-languages</comment> command', 'cli')
             ->addOption(
-                'debug', 'd', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'Debug features: '.implode(', ', array_map(function($f) { return "<info>{$f}</info>"; }, $this->_debug))
+                'debug',
+                'd',
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'Debug features: ' . implode(', ', array_map(function ($f) {
+                    return "<info>{$f}</info>";
+                }, $this->_debug))
             )
             ->setDescription('<comment>[DEFAULT]</comment> Highlights given file')
         ;
@@ -49,26 +53,26 @@ class HighlightCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if(!empty($input->getOption('debug')) && $output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
+        if (!empty($input->getOption('debug')) && $output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
             $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         }
 
-        $output->writeln($this->getApplication()->getLongVersion()."\n", Output::VERBOSITY_VERBOSE);
+        $output->writeln($this->getApplication()->getLongVersion() . "\n", Output::VERBOSITY_VERBOSE);
         $formatter = KeyLighter::get()->getFormatter($input->getOption('format')) ?: KeyLighter::get()->getDefaultFormatter();
 
-        foreach($input->getArgument('path') as $filename) {
+        foreach ($input->getArgument('path') as $filename) {
             $this->process($input, $output, $filename, $formatter);
         }
     }
 
     protected function content($path, $normalize = false)
     {
-        if(!($file = @fopen($path, 'r'))) {
+        if (!($file = @fopen($path, 'r'))) {
             return false;
         }
 
         $content = '';
-        while(!feof($file)) {
+        while (!feof($file)) {
             $content .= fgets($file);
         }
         fclose($file);
@@ -95,14 +99,18 @@ class HighlightCommand extends Command
             : Language::byFilename($filename);
 
         if (!($source = $this->content($filename, $input->getOption('normalize')))) {
-            throw new InvalidArgumentException(sprintf('Specified file %s doesn\'t exist, check if given path is correct.',
-                $filename));
+            throw new InvalidArgumentException(sprintf(
+                'Specified file %s doesn\'t exist, check if given path is correct.',
+                $filename
+            ));
         }
 
         if ($output->isVerbose()) {
             $output->writeln(sprintf(
                 "Used file: <path>%s</path>, Language: <language>%s</language>, Formatter: <formatter>%s</formatter>",
-                $filename, $language->getFQN(), get_class($formatter)
+                $filename,
+                $language->getFQN(),
+                get_class($formatter)
             ));
 
             $verbose   = new VerboseOutput($output, $input, $language, $formatter, $source);

--- a/bin/Commands/LanguagesCommand.php
+++ b/bin/Commands/LanguagesCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin\Commands;
-
 
 use Kadet\Highlighter\KeyLighter;
 use Symfony\Component\Console\Command\Command;
@@ -32,7 +32,9 @@ class LanguagesCommand extends Command
     protected function configure()
     {
         $this->setName('languages')
-            ->addArgument('by', InputArgument::OPTIONAL, 'Alias type, one of '.implode(', ', array_map(function($f) { return "<info>{$f}</info>"; }, $this->types)), 'name')
+            ->addArgument('by', InputArgument::OPTIONAL, 'Alias type, one of ' . implode(', ', array_map(function ($f) {
+                return "<info>{$f}</info>";
+            }, $this->types)), 'name')
             ->addOption('no-group', 'g', InputOption::VALUE_NONE, 'Do not group languages by type')
             ->addOption('classes', 'c', InputOption::VALUE_NONE, 'Return fully qualified class names instead of identifiers')
             ->addOption('headerless', 'l', InputOption::VALUE_NONE, 'Output table without headers, useful for parsing')
@@ -46,13 +48,15 @@ class LanguagesCommand extends Command
 
         $table = new Table($output);
 
-        if(!$input->getOption('headerless')) {
+        if (!$input->getOption('headerless')) {
             $table->setHeaders([ucfirst($input->getArgument('by')), $input->getOption('classes') ? 'Class name' : 'Language']);
         }
 
-        $table->setRows(array_map(function($language) {
+        $table->setRows(array_map(function ($language) {
             return [
-                implode(', ', array_map(function ($f) { return "<comment>{$f}</comment>"; }, $language['aliases'])),
+                implode(', ', array_map(function ($f) {
+                    return "<comment>{$f}</comment>";
+                }, $language['aliases'])),
                 $language['class']
             ];
         }, $input->getOption('no-group') ? $this->processNonGrouped($languages) : $this->processGrouped($languages)));
@@ -61,10 +65,11 @@ class LanguagesCommand extends Command
         $table->render();
     }
 
-    protected function processGrouped($languages) {
+    protected function processGrouped($languages)
+    {
         $result = [];
-        foreach($languages as $alias => $class) {
-            if(!isset($result[$class])) {
+        foreach ($languages as $alias => $class) {
+            if (!isset($result[$class])) {
                 $result[$class] = ['aliases' => [], 'class' => $class];
             }
 
@@ -74,9 +79,10 @@ class LanguagesCommand extends Command
         return $result;
     }
 
-    protected function processNonGrouped($languages) {
+    protected function processNonGrouped($languages)
+    {
         $result = [];
-        foreach($languages as $alias => $class) {
+        foreach ($languages as $alias => $class) {
             $result[] = ['aliases' => [$alias], 'class' => $class];
         }
 

--- a/bin/Commands/Test/RegenerateCommand.php
+++ b/bin/Commands/Test/RegenerateCommand.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Kadet\Highlighter\bin\Commands\Test;
-
 
 use Kadet\Highlighter\Formatter\FormatterInterface;
 use Kadet\Highlighter\KeyLighter;
@@ -41,8 +39,8 @@ class RegenerateCommand extends Command
         $this->_keylighter = KeyLighter::get();
         $this->_formatter  = new TestFormatter();
 
-        $this->_input  = realpath(__DIR__.'/../../../Tests/Samples');
-        $this->_output = realpath(__DIR__.'/../../../Tests/Expected/Test');
+        $this->_input  = realpath(__DIR__ . '/../../../Tests/Samples');
+        $this->_output = realpath(__DIR__ . '/../../../Tests/Expected/Test');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -51,7 +49,8 @@ class RegenerateCommand extends Command
             new \RecursiveDirectoryIterator(
                 $this->_input,
                 \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::UNIX_PATHS
-            ), \RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         $reviewer = $this->_keylighter->getFormatter($input->getOption('review') ?: 'cli');
@@ -59,7 +58,7 @@ class RegenerateCommand extends Command
         /** @var \SplFileInfo $file */
         foreach ($iterator as $file) {
             $pathname = substr($file->getPathname(), strlen($this->_input) + 1);
-            if(!$this->regenerate($input, $pathname)) {
+            if (!$this->regenerate($input, $pathname)) {
                 continue;
             }
 
@@ -71,8 +70,8 @@ class RegenerateCommand extends Command
             if ($this->review($input, $output, $tokens, $reviewer)) {
                 $result = StringHelper::normalize($this->_formatter->format($tokens));
 
-                if(!file_exists($this->_output.'/'.dirname($pathname))) {
-                    mkdir($this->_output.'/'.dirname($pathname), 0755, true);
+                if (!file_exists($this->_output . '/' . dirname($pathname))) {
+                    mkdir($this->_output . '/' . dirname($pathname), 0755, true);
                 }
 
                 file_put_contents("{$this->_output}/$pathname.tkn", $result);
@@ -99,16 +98,17 @@ class RegenerateCommand extends Command
             || $input->hasParameterOption('-r');
     }
 
-    private function regenerate(InputInterface $input, $filename) {
+    private function regenerate(InputInterface $input, $filename)
+    {
         $filename = str_replace(DIRECTORY_SEPARATOR, '/', $filename);
         $patterns = $input->getArgument('files');
 
-        foreach($patterns as $pattern) {
-            if($input->getOption('new') && file_exists("{$this->_output}/$filename.tkn")) {
+        foreach ($patterns as $pattern) {
+            if ($input->getOption('new') && file_exists("{$this->_output}/$filename.tkn")) {
                 continue;
             }
 
-            if(fnmatch($pattern, $filename)) {
+            if (fnmatch($pattern, $filename)) {
                 return true;
             }
         }

--- a/bin/VerboseOutput.php
+++ b/bin/VerboseOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Highlighter
  *
@@ -14,7 +15,6 @@
  */
 
 namespace Kadet\Highlighter\bin;
-
 
 use Kadet\Highlighter\Formatter\DebugFormatter;
 use Kadet\Highlighter\Formatter\FormatterInterface;
@@ -52,7 +52,11 @@ class VerboseOutput
      * @param                    $source
      */
     public function __construct(
-        OutputInterface $output, InputInterface $input, Language $language, FormatterInterface $formatter, $source
+        OutputInterface $output,
+        InputInterface $input,
+        Language $language,
+        FormatterInterface $formatter,
+        $source
     ) {
         $this->_output = $output;
         $this->_input  = $input;
@@ -70,28 +74,29 @@ class VerboseOutput
         $parsed    = $this->parse($tokenized);
         $formatted = $this->format($parsed);
 
-        if($this->wants('time')) {
+        if ($this->wants('time')) {
             $this->_output->writeln(sprintf(
                 '<info>Overall:</info> %.4fs, %s chars/s',
-                array_sum($this->_times), number_format(strlen($this->_source) / array_sum($this->_times))
+                array_sum($this->_times),
+                number_format(strlen($this->_source) / array_sum($this->_times))
             ));
         }
 
-        if($this->wants('detailed-time')) {
-            $this->_slashed('Times             [s]', array_map(function($t) {
+        if ($this->wants('detailed-time')) {
+            $this->_slashed('Times             [s]', array_map(function ($t) {
                 return number_format($t, 5);
             }, $this->_times));
-            $this->_slashed('Performance [chars/s]', array_map(function($t) {
+            $this->_slashed('Performance [chars/s]', array_map(function ($t) {
                 return number_format(strlen($this->_source) / $t);
             }, $this->_times));
         }
 
-        if($this->wants('count')) {
+        if ($this->wants('count')) {
             $this->_slashed('Token count', array_map('number_format', $this->_counts));
         }
 
-        if($this->wants('density')) {
-            $this->_slashed('Token density [tokens/kB]', array_map(function($c) {
+        if ($this->wants('density')) {
+            $this->_slashed('Token density [tokens/kB]', array_map(function ($c) {
                 return number_format($c / strlen($this->_source) * 1024, 1);
             }, $this->_counts));
         }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "ext-json": "*",
     "easybook/geshi": "v1.0.8.19",
     "phpunit/phpunit": "^7.0",
+    "squizlabs/php_codesniffer": "^3.5",
     "symfony/console": "^4.4",
     "symfony/var-exporter": "^4.4"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6176d7696c4f341d826f6aab8211fe8",
+    "content-hash": "45a8fa96e4c4016b2659b11c5ef370da",
     "packages": [],
     "packages-dev": [
         {
@@ -1423,6 +1423,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-01-30T22:20:29+00:00"
         },
         {
             "name": "symfony/console",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset name="keylighter">
+    <description>Keylighter coding standards</description>
+
+    <file>./bin/</file>
+    <file>./Config/formatters.php</file>
+    <file>./Exceptions/</file>
+    <file>./Formatter/</file>
+    <file>./Language/</file>
+    <file>./Matcher/</file>
+    <file>./Parser/</file>
+    <file>./Styles/Cli/default.php</file>
+    <file>./Styles/Latex/default.php</file>
+    <file>./Tests/</file>
+
+    <exclude-pattern>./Tests/Samples/</exclude-pattern>
+
+    <rule ref="PSR12">
+        <!-- Ignore too long lines -->
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+
+        <!-- Ignore private properties prefixed with underscore -->
+        <exclude name="PSR2.Classes.PropertyDeclaration" />
+
+        <!-- Ignore private methods prefixed with underscore -->
+        <exclude name="PSR2.Methods.MethodDeclaration" />
+
+        <!-- Ignore missing constant visibility modifier -->
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>./Tests/GreedyLanguageTest.php</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>./Tests/GreedyLanguageTest.php</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Re-opened to come from the original repository, not from the fork.

This needs the decision:

A) We use inline phpcs annotations to disable checking for `Language::setupRules()` - I failed trying to do so, btw

B) We accept codestyle fixes (leaving those `Rule` indentations as they were before) but remove phpcs altogether

C) We accept it as-is and move on.

Second point is that it somehow broke one test. Help would be appreciated.