### PR TITLE
Add support for annotations inside JSDoc comments

### DIFF
--- a/Language/JavaScript.php
+++ b/Language/JavaScript.php
@@ -61,7 +61,14 @@ class JavaScript extends GreedyLanguage
                 'context' => ['string']
             ]),
 
-            'comment' => new Rule(new CommentMatcher(['//'], [['/*', '*/']]), ['priority' => 3]),
+            'comment' => new Rule(new CommentMatcher(['//'], [
+                '$.docblock' => ['/**', '*/'],
+                ['/*', '*/']
+            ]), ['priority' => 3]),
+
+            'symbol.annotation' => new Rule(new RegexMatcher('/[\s]+(@[\w-]+)/i'), [
+                'context' => ['comment.docblock']
+            ]),
 
             'call' => new Rule(new RegexMatcher('/(' . self::IDENTIFIER . ')\s*\(/iu'), ['priority' => -1]),
 

--- a/Tests/Expected/Test/js/small.js.tkn
+++ b/Tests/Expected/Test/js/small.js.tkn
@@ -2,7 +2,7 @@
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}export{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}default{/keyword:Kadet\Highlighter\Parser\Token\Token} {
   props: {
-    {comment:Kadet\Highlighter\Parser\Token\Token}/** @property {string} uuid */{/comment:Kadet\Highlighter\Parser\Token\Token}
+    {comment.docblock:Kadet\Highlighter\Parser\Token\Token}/** {symbol.annotation:Kadet\Highlighter\Parser\Token\Token}@property{/symbol.annotation:Kadet\Highlighter\Parser\Token\Token} {string} uuid */{/comment.docblock:Kadet\Highlighter\Parser\Token\Token}
     asset: {
       type: Object{operator.punctuation:Kadet\Highlighter\Parser\Token\Token},{/operator.punctuation:Kadet\Highlighter\Parser\Token\Token}
       required: {constant.special:Kadet\Highlighter\Parser\Token\Token}true{/constant.special:Kadet\Highlighter\Parser\Token\Token}{operator.punctuation:Kadet\Highlighter\Parser\Token\Token},{/operator.punctuation:Kadet\Highlighter\Parser\Token\Token}

--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,8 @@
  * **XML** now correctly matches closing tags with `-`
  * **Java** fix #4 - class names in declarations and instantiations are now highlighted correctly
  * **Shell** highlighting now matches parameters and paths with `do` correctly
+ * **JavaScript** and **TypeScript** now correctly recognize JSDoc comments as docblock tokens
+ * **JavaScript** and **TypeScript** now correctly highlight annotations inside JSDoc comments
  
 ## 16.09.2016 [0.8.2]
 ### Fixed


### PR DESCRIPTION
Almost direct copy&paste from PHP so hopefully it will work fine.