### PR TITLE
Switch whole project to use strict type checks

### DIFF
--- a/Exceptions/NameConflictException.php
+++ b/Exceptions/NameConflictException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Exceptions;
 
 class NameConflictException extends \LogicException

--- a/Exceptions/NoSuchElementException.php
+++ b/Exceptions/NoSuchElementException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Exceptions;
 
 use Symfony\Component\Console\Exception\LogicException;

--- a/Formatter/AbstractFormatter.php
+++ b/Formatter/AbstractFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Formatter;
 
 use Kadet\Highlighter\Parser\Token\Token;

--- a/Formatter/CliFormatter.php
+++ b/Formatter/CliFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Formatter/DebugFormatter.php
+++ b/Formatter/DebugFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Formatter/FormatterInterface.php
+++ b/Formatter/FormatterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Formatter/LatexFormatter.php
+++ b/Formatter/LatexFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Apache.php
+++ b/Language/Apache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Language/Assembler.php
+++ b/Language/Assembler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/C.php
+++ b/Language/C.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/CSharp.php
+++ b/Language/CSharp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Cobol.php
+++ b/Language/Cobol.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Language;
 
 use Kadet\Highlighter\Matcher\CommentMatcher;

--- a/Language/CommonFeatures.php
+++ b/Language/CommonFeatures.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Cpp.php
+++ b/Language/Cpp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Css.php
+++ b/Language/Css.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Css/Less.php
+++ b/Language/Css/Less.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Css/PreProcessor.php
+++ b/Language/Css/PreProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Css/Sass.php
+++ b/Language/Css/Sass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Css/Scss.php
+++ b/Language/Css/Scss.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Go.php
+++ b/Language/Go.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/GreedyLanguage.php
+++ b/Language/GreedyLanguage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Haskell.php
+++ b/Language/Haskell.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Html.php
+++ b/Language/Html.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Http.php
+++ b/Language/Http.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Ini.php
+++ b/Language/Ini.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Java.php
+++ b/Language/Java.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/JavaScript.php
+++ b/Language/JavaScript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Language.php
+++ b/Language/Language.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Latex.php
+++ b/Language/Latex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Markdown.php
+++ b/Language/Markdown.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Perl.php
+++ b/Language/Perl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Php.php
+++ b/Language/Php.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/PlainText.php
+++ b/Language/PlainText.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/PowerShell.php
+++ b/Language/PowerShell.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Prolog.php
+++ b/Language/Prolog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Python.php
+++ b/Language/Python.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Python/Django.php
+++ b/Language/Python/Django.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Ruby.php
+++ b/Language/Ruby.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Shell.php
+++ b/Language/Shell.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Sql.php
+++ b/Language/Sql.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Sql/MySql.php
+++ b/Language/Sql/MySql.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Twig.php
+++ b/Language/Twig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Language;
 
 use Kadet\Highlighter\Language\Python\Django;

--- a/Language/TypeScript.php
+++ b/Language/TypeScript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Language;
 
 use Kadet\Highlighter\Matcher\RegexMatcher;

--- a/Language/UnifiedDiff.php
+++ b/Language/UnifiedDiff.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Xaml.php
+++ b/Language/Xaml.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Language/Xml.php
+++ b/Language/Xml.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Matcher/CommentMatcher.php
+++ b/Matcher/CommentMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Matcher/DelegateRegexMatcher.php
+++ b/Matcher/DelegateRegexMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Matcher/MatcherInterface.php
+++ b/Matcher/MatcherInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Matcher/RegexMatcher.php
+++ b/Matcher/RegexMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Matcher/SubStringMatcher.php
+++ b/Matcher/SubStringMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Matcher/WholeMatcher.php
+++ b/Matcher/WholeMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Matcher/WordMatcher.php
+++ b/Matcher/WordMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/CloseRule.php
+++ b/Parser/CloseRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Parser/Context.php
+++ b/Parser/Context.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/DelegateTokenFactory.php
+++ b/Parser/DelegateTokenFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/OpenRule.php
+++ b/Parser/OpenRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Parser/Result.php
+++ b/Parser/Result.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Rule.php
+++ b/Parser/Rule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Rules.php
+++ b/Parser/Rules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Token/ContextualToken.php
+++ b/Parser/Token/ContextualToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Parser/Token/LanguageToken.php
+++ b/Parser/Token/LanguageToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Token/MetaToken.php
+++ b/Parser/Token/MetaToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Token/TerminatorToken.php
+++ b/Parser/Token/TerminatorToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Token/Token.php
+++ b/Parser/Token/Token.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/TokenFactory.php
+++ b/Parser/TokenFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/TokenFactoryInterface.php
+++ b/Parser/TokenFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/TokenIterator.php
+++ b/Parser/TokenIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Tokens.php
+++ b/Parser/Tokens.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/UnprocessedTokens.php
+++ b/Parser/UnprocessedTokens.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Validator/DelegateValidator.php
+++ b/Parser/Validator/DelegateValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Parser/Validator/Validator.php
+++ b/Parser/Validator/Validator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/ArrayHelperTest.php
+++ b/Tests/ArrayHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/CliFormatterTest.php
+++ b/Tests/CliFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/ConsoleHelperTest.php
+++ b/Tests/ConsoleHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Constraint/TokensMatches.php
+++ b/Tests/Constraint/TokensMatches.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/ContextTest.php
+++ b/Tests/ContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/DelegateTokenFactoryTest.php
+++ b/Tests/DelegateTokenFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/GreedyLanguageTest.php
+++ b/Tests/GreedyLanguageTest.php
@@ -64,7 +64,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 3, 'name' => 'number'],
                 ['end', 'pos' => 5, 'name' => 'number'],
             ['end', 'pos' => 5, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('if 12')), true);
+        ], iterator_to_array($language->parse('if 12'), true));
     }
 
     public function testManyRules()
@@ -83,7 +83,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 3, 'name' => 'keyword'],
                 ['end', 'pos' => 5, 'name' => 'keyword'],
             ['end', 'pos' => 5, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('if or')), true);
+        ], iterator_to_array($language->parse('if or'), true));
     }
 
     public function testNestedTokens()
@@ -100,7 +100,7 @@ class GreedyLanguageTest extends MatcherTestCase
                     ['end', 'pos' => 3, 'name' => 'or'],
                 ['end', 'pos' => 3, 'name' => 'for'],
             ['end', 'pos' => 3, 'name' => 'language.mock'],
-        ], iterator_to_array($language->tokenize('for')), true);
+        ], iterator_to_array($language->tokenize('for'), true));
     }
 
     public function testInvalidTokens()
@@ -115,7 +115,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 0, 'name' => 'for'],
                 ['end', 'pos' => 3, 'name' => 'for'],
             ['end', 'pos' => 3, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('for')), true);
+        ], iterator_to_array($language->parse('for'), true));
     }
 
     public function testLanguageEmbeddingByItself()
@@ -133,7 +133,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 8, 'name' => 'language.embedded'],
                 ['end', 'pos' => 19, 'name' => 'language.embedded'],
             ['end', 'pos' => 19, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('keyword { keyword }')), true);
+        ], iterator_to_array($language->parse('keyword { keyword }'), true));
     }
 
     public function testLanguageEmbeddingByParent()
@@ -154,7 +154,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 8, 'name' => 'language.embedded'],
                 ['end', 'pos' => 19, 'name' => 'language.embedded'],
             ['end', 'pos' => 19, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('keyword { keyword }')), true);
+        ], iterator_to_array($language->parse('keyword { keyword }'), true));
     }
 
     public function testUnclosedTokens()
@@ -168,7 +168,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 3, 'name' => 'keyword'],
                 ['end', 'pos' => 7, 'name' => 'keyword'],
             ['end', 'pos' => 7, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('te ( st')), true);
+        ], iterator_to_array($language->parse('te ( st'), true));
     }
 
     public function testRangeTokens()
@@ -185,7 +185,7 @@ class GreedyLanguageTest extends MatcherTestCase
                 ['start', 'pos' => 4, 'name' => 'keyword'],
                 ['end', 'pos' => 11, 'name' => 'keyword'],
             ['end', 'pos' => 15, 'name' => 'language.mock'],
-        ], iterator_to_array($language->parse('foo ( bar ) foo')), true);
+        ], iterator_to_array($language->parse('foo ( bar ) foo'), true));
     }
 
     public function testOptions()

--- a/Tests/GreedyLanguageTest.php
+++ b/Tests/GreedyLanguageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/HelperTest.php
+++ b/Tests/HelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Helpers/TestFormatter.php
+++ b/Tests/Helpers/TestFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Tests\Helpers;
 
 use Kadet\Highlighter\Formatter\FormatterInterface;

--- a/Tests/HtmlFormatterTest.php
+++ b/Tests/HtmlFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/KeyLighterTest.php
+++ b/Tests/KeyLighterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/LanguagesTest.php
+++ b/Tests/LanguagesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\Tests;
 
 use Kadet\Highlighter\KeyLighter;

--- a/Tests/MatcherTestCase.php
+++ b/Tests/MatcherTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/CommentMatcherTest.php
+++ b/Tests/Matchers/CommentMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/DelegateRegexMatcherTest.php
+++ b/Tests/Matchers/DelegateRegexMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/RegexMatcherTest.php
+++ b/Tests/Matchers/RegexMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/SubStringMatcherTest.php
+++ b/Tests/Matchers/SubStringMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/WholeMatcherTest.php
+++ b/Tests/Matchers/WholeMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Matchers/WordMatcherTest.php
+++ b/Tests/Matchers/WordMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Mocks/MockGreedyLanguage.php
+++ b/Tests/Mocks/MockGreedyLanguage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/RuleTest.php
+++ b/Tests/RuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/RulesTest.php
+++ b/Tests/RulesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/StringHelperTest.php
+++ b/Tests/StringHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/TokenFactoryTest.php
+++ b/Tests/TokenFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/TokenIteratorTest.php
+++ b/Tests/TokenIteratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/TokenListTest.php
+++ b/Tests/TokenListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/ContextualTokenTest.php
+++ b/Tests/Tokens/ContextualTokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/LanguageTokenTest.php
+++ b/Tests/Tokens/LanguageTokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/MetaTokenTest.php
+++ b/Tests/Tokens/MetaTokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/TerminatorTokenTest.php
+++ b/Tests/Tokens/TerminatorTokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/TokenComparisonTest.php
+++ b/Tests/Tokens/TokenComparisonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/TokenTest.php
+++ b/Tests/Tokens/TokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/Tokens/TokenTestCase.php
+++ b/Tests/Tokens/TokenTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Tests/ValidatorTest.php
+++ b/Tests/ValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Utils/ArrayHelper.php
+++ b/Utils/ArrayHelper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Utils/Console.php
+++ b/Utils/Console.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Utils/ConsoleHelper.php
+++ b/Utils/ConsoleHelper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Utils/Helper.php
+++ b/Utils/Helper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *1

--- a/Utils/Singleton.php
+++ b/Utils/Singleton.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/Utils/StringHelper.php
+++ b/Utils/StringHelper.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Application.php
+++ b/bin/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/Benchmark/AnalyzeCommand.php
+++ b/bin/Commands/Benchmark/AnalyzeCommand.php
@@ -124,7 +124,7 @@ class AnalyzeCommand extends Command
 
     private function format($number)
     {
-        return is_numeric($number) ? number_format($number, 2) : $number;
+        return is_numeric($number) ? number_format((float) $number, 2) : $number;
     }
 
     private function avarage(array $result)

--- a/bin/Commands/Benchmark/AnalyzeCommand.php
+++ b/bin/Commands/Benchmark/AnalyzeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/Benchmark/RunCommand.php
+++ b/bin/Commands/Benchmark/RunCommand.php
@@ -79,7 +79,7 @@ class RunCommand extends Command
             $times  = [];
             $memory = [];
 
-            for ($i = $input->getOption('times'), $progress = new ProgressBar($output, $i); $i > 0; $i--) {
+            for ($i = (int) $input->getOption('times'), $progress = new ProgressBar($output, $i); $i > 0; $i--) {
                 $progress->display();
                 $result = $this->benchmark($source, $language, $formatter);
                 $times  = array_merge_recursive($times, $result['times']);

--- a/bin/Commands/Benchmark/RunCommand.php
+++ b/bin/Commands/Benchmark/RunCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/Dev/GenerateMetadataCommand.php
+++ b/bin/Commands/Dev/GenerateMetadataCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/Dev/GenerateTableCommand.php
+++ b/bin/Commands/Dev/GenerateTableCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/FormattersCommand.php
+++ b/bin/Commands/FormattersCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/HighlightCommand.php
+++ b/bin/Commands/HighlightCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/LanguagesCommand.php
+++ b/bin/Commands/LanguagesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *

--- a/bin/Commands/Test/RegenerateCommand.php
+++ b/bin/Commands/Test/RegenerateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kadet\Highlighter\bin\Commands\Test;
 
 use Kadet\Highlighter\Formatter\FormatterInterface;

--- a/bin/VerboseOutput.php
+++ b/bin/VerboseOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Highlighter
  *


### PR DESCRIPTION
I decided that if we want to enter the typed PHP world we should do this step by step. Adding `declare(strict_types=1)` to every single file in multiple (upcoming!) pull requests seemed like wasted effort. Therefore, I think we should do it all at once.

I temporarily kept second commit to show you how little changes were required to make the project running with strictly checked types. Literally two lines changed and one little mistake copy&pasted a couple of times in single test :D

Good job, seriously!

I'm of course scared if the project actually still works. I run all CLI commands one by one, I tested highlightning some random files, I checked phpStorm inspections for every single changed file and I obviously run the test suite. Not sure what else can be done in reasonable time.