### PR TITLE
PHP8 support

### DIFF
--- a/Parser/Rules.php
+++ b/Parser/Rules.php
@@ -192,7 +192,7 @@ class Rules extends \ArrayObject
             return [];
         }
 
-        return call_user_func_array('array_merge', $items);
+        return call_user_func_array('array_merge', array_values($items));
     }
 
     /**

--- a/Parser/Token/Token.php
+++ b/Parser/Token/Token.php
@@ -69,7 +69,7 @@ class Token
 
         $this->name     = $name;
         $this->rule     = isset($options['rule']) ? $options['rule'] : new Rule();
-        $this->options = $options;
+        $this->options  = $options;
 
         $this->id = ++self::$_id;
     }

--- a/Parser/Token/Token.php
+++ b/Parser/Token/Token.php
@@ -69,7 +69,7 @@ class Token
 
         $this->name     = $name;
         $this->rule     = isset($options['rule']) ? $options['rule'] : new Rule();
-        $this->options &= $options;
+        $this->options = $options;
 
         $this->id = ++self::$_id;
     }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": "^7.1.3"
+    "php": "^7.1.3 | ^8.0"
   },
   "require-dev": {
     "ext-json": "*",


### PR DESCRIPTION
Hello,

I updated a few things to get the tests running on PHP. The tests are also running on a project which consumes this lib on PHP8 too, which failed before these changes.

There is 1 change I'm not too sure about though - the removal of the bitwise AND in the Token class. Could you maybe shed some light on the intention of the original code?

Thanks!