### PR TITLE
[WIP] Batch highlightining

### DIFF
--- a/Config/metadata.php
+++ b/Config/metadata.php
@@ -32,6 +32,25 @@ return [
         'injectable' => false,
     ],
     [
+        'Kadet\\Highlighter\\Language\\Batch',
+        'name' => [
+            'bat',
+            'batch',
+            'dos',
+        ],
+        'mime' => [
+            'application/bat',
+            'application/x-bat',
+            'application/x-msdos-program',
+        ],
+        'extension' => [
+            '*.bat',
+            '*.cmd',
+        ],
+        'standalone' => true,
+        'injectable' => false,
+    ],
+    [
         'Kadet\\Highlighter\\Language\\C',
         'name' => [
             'c',

--- a/Docs/A-languages.md
+++ b/Docs/A-languages.md
@@ -38,6 +38,7 @@ Class | Name | MIME | Extension
 ------|------|------|----------
 `Kadet\Highlighter\Language\Apache` | `apache` | none | `.htaccess`
 `Kadet\Highlighter\Language\Assembler` | `asm`, `assembler` | `text/x-asm` | `*.asm`
+`Kadet\Highlighter\Language\Batch` | `bat`, `batch`, `dos` | `application/bat`, `application/x-bat`, `application/x-msdos-program` | `*.bat`, `*.cmd`
 `Kadet\Highlighter\Language\C` | `c` | `text/x-csrc`, `text/x-chdr` | `*.c`, `*.h`, `*.idc`
 `Kadet\Highlighter\Language\CSharp` | `CSharp`, `C#` | `text/x-csharp` | `*.cs`
 `Kadet\Highlighter\Language\Cobol` | `cobol` | `text/x-cobol` | `*.cbl`

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -37,20 +37,21 @@ class Batch extends GreedyLanguage
                 new Rule(new CommentMatcher(['::'])),
             ],
 
-            'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 2]),
-
-            'keyword' => new Rule(new WordMatcher([
-                'ASSOC', 'ATTRIB', 'BREAK', 'BCDEDIT', 'CACLS', 'CD', 'CHCP', 'CHDIR', 'CHKDSK', 'CHKNTFS',
-                'CLS', 'CMD', 'COLOR', 'COMP', 'COMPACT', 'CONVERT', 'COPY', 'DATE', 'DEL', 'DIR', 'DISKCOMP',
-                'DISKCOPY', 'DISKPART', 'DOSKEY', 'DRIVERQUERY', 'ECHO', 'ENDLOCAL', 'ERASE', 'EXIT', 'FC',
-                'FIND', 'FINDSTR', 'FOR', 'FORMAT', 'FSUTIL', 'FTYPE', 'GPRESULT', 'GRAFTABL', 'HELP', 'ICACLS',
-                'IF', 'LABEL', 'MD', 'MKDIR', 'MKLINK', 'MODE', 'MORE', 'MOVE', 'OPENFILES', 'PATH', 'PAUSE',
-                'POPD', 'PRINT', 'PROMPT', 'PUSHD', 'RD', 'RECOVER', 'REN', 'RENAME', 'REPLACE', 'RMDIR',
-                'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
-                'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
-                'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
-                'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
-            ]), ['priority' => 3]),
+            'keyword' => [
+                new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 3]),
+                new Rule(new WordMatcher([
+                    'ASSOC', 'ATTRIB', 'BREAK', 'BCDEDIT', 'CACLS', 'CD', 'CHCP', 'CHDIR', 'CHKDSK', 'CHKNTFS',
+                    'CLS', 'CMD', 'COLOR', 'COMP', 'COMPACT', 'CONVERT', 'COPY', 'DATE', 'DEL', 'DIR', 'DISKCOMP',
+                    'DISKCOPY', 'DISKPART', 'DOSKEY', 'DRIVERQUERY', 'ECHO', 'ENDLOCAL', 'ERASE', 'EXIT', 'FC',
+                    'FIND', 'FINDSTR', 'FOR', 'FORMAT', 'FSUTIL', 'FTYPE', 'GPRESULT', 'GRAFTABL', 'HELP', 'ICACLS',
+                    'IF', 'LABEL', 'MD', 'MKDIR', 'MKLINK', 'MODE', 'MORE', 'MOVE', 'OPENFILES', 'PATH', 'PAUSE',
+                    'POPD', 'PRINT', 'PROMPT', 'PUSHD', 'RD', 'RECOVER', 'REN', 'RENAME', 'REPLACE', 'RMDIR',
+                    'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
+                    'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
+                    'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
+                    'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
+                ]), ['priority' => 3]),
+            ],
 
             'variable'  => [
                 'assign' => new Rule(new RegexMatcher('/(\w+)[+-]?=/')),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -35,8 +35,6 @@ class Batch extends GreedyLanguage
                 new Rule(new RegexMatcher('/^\s*(rem\s+.+)/mi')),
             ],
 
-            'string' => CommonFeatures::strings(['single' => '\'', 'double' => '"']),
-
             'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 2]),
 
             'keyword' => new Rule(new WordMatcher([
@@ -54,8 +52,8 @@ class Batch extends GreedyLanguage
 
             'variable'  => [
                 'assign' => new Rule(new RegexMatcher('/(\w+)[+-]?=/')),
-                new Rule(new RegexMatcher('/(%\w+%)/i'), ['context' => ['*none', '*string.double']]),
-                new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none', '*string.double']]),
+                new Rule(new RegexMatcher('/(%\w+%)/i'), ['context' => ['*none']]),
+                new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none']]),
             ],
 
             'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Kadet\Highlighter\Language;
 
+use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;
 use Kadet\Highlighter\Parser\Rule;
@@ -33,6 +34,7 @@ class Batch extends GreedyLanguage
             'comment' => [
                 new Rule(new RegexMatcher('/^\s*(rem)[\t\n\r]+/mi')),
                 new Rule(new RegexMatcher('/^\s*(rem\s+.+)/mi')),
+                new Rule(new CommentMatcher(['::'])),
             ],
 
             'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 2]),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -61,6 +61,11 @@ class Batch extends GreedyLanguage
             'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),
             'delimiter' => new Rule(new RegexMatcher('/^(\$)/m')),
 
+            'symbol.parameter' => new Rule(new RegexMatcher('/(\/[a-z])\b/i'), [
+                'priority' => 0,
+                'context'  => ['!comment'],
+            ]),
+
             'expression' => [
                 new Rule(new RegexMatcher('/(?=(\$\(((?>[^$()]+|(?1))+)\)))/x'), [
                     'context' => Validator::everywhere(),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -37,6 +37,8 @@ class Batch extends GreedyLanguage
                 new Rule(new CommentMatcher(['::'])),
             ],
 
+            'string' => new Rule(new RegexMatcher('/^\s*@?echo[ \t]+(.+)\s/mi'), ['priority' => 2]),
+
             'keyword' => [
                 new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 3]),
                 new Rule(new WordMatcher([
@@ -55,8 +57,8 @@ class Batch extends GreedyLanguage
 
             'variable'  => [
                 'assign' => new Rule(new RegexMatcher('/(\w+)[+-]?=/')),
-                new Rule(new RegexMatcher('/(%\w+%)/i'), ['context' => ['*none']]),
-                new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none']]),
+                new Rule(new RegexMatcher('/(%\w+%)/i'), ['context' => ['*none', '*string'], 'priority' => 4]),
+                new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none', '*string'], 'priority' => 4]),
             ],
 
             'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -58,7 +58,7 @@ class Batch extends GreedyLanguage
                 new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none', '*string'], 'priority' => 4]),
             ],
 
-            'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),
+            'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/', ['context' => '!comment'])),
             'delimiter' => new Rule(new RegexMatcher('/^(\$)/m')),
 
             'symbol.parameter' => new Rule(new RegexMatcher('/(\/[a-z])\b/i'), [

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -38,7 +38,7 @@ class Batch extends GreedyLanguage
 
             'string' => CommonFeatures::strings(['single' => '\'', 'double' => '"']),
 
-            'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 3]),
+            'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 2]),
 
             'keyword' => new Rule(new WordMatcher([
                 'ASSOC', 'ATTRIB', 'BREAK', 'BCDEDIT', 'CACLS', 'CD', 'CHCP', 'CHDIR', 'CHKDSK', 'CHKNTFS',
@@ -50,7 +50,7 @@ class Batch extends GreedyLanguage
                 'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
                 'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
                 'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
-                'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
+                'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
             ]), ['priority' => 3]),
 
             'variable'  => [

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -31,9 +31,14 @@ class Batch extends GreedyLanguage
     public function setupRules()
     {
         $this->rules->addMany([
-//            'comment' => new Rule(new RegexMatcher('/^[ ]*(rem[^\r\n\w]*)/mi')),
-            'comment' => new Rule(new RegexMatcher('/^[ ]*(rem)( [ \w]*)?$/mi')),
+            'comment' => [
+                new Rule(new RegexMatcher('/^\s*(rem)[\t\n\r]+/mi')),
+                new Rule(new RegexMatcher('/^\s*(rem\s+.+)/mi')),
+            ],
+
             'string' => CommonFeatures::strings(['single' => '\'', 'double' => '"']),
+
+            'keyword.special' => new Rule(new RegexMatcher('/^\s*(@?echo(\s+(on|off))?)\b/mi'), ['priority' => 3]),
 
             'keyword' => new Rule(new WordMatcher([
                 'ASSOC', 'ATTRIB', 'BREAK', 'BCDEDIT', 'CACLS', 'CD', 'CHCP', 'CHDIR', 'CHKDSK', 'CHKNTFS',
@@ -45,7 +50,7 @@ class Batch extends GreedyLanguage
                 'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
                 'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
                 'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
-                'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
+                'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
             ]), ['priority' => 3]),
 
             'variable'  => [

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -22,7 +22,6 @@ use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;
 use Kadet\Highlighter\Parser\Rule;
 use Kadet\Highlighter\Parser\Token\LanguageToken;
-use Kadet\Highlighter\Parser\Token\Token;
 use Kadet\Highlighter\Parser\TokenFactory;
 use Kadet\Highlighter\Parser\Validator\Validator;
 
@@ -55,10 +54,8 @@ class Batch extends GreedyLanguage
 
             'variable'  => [
                 'assign' => new Rule(new RegexMatcher('/(\w+)[+-]?=/')),
-                new Rule(new RegexMatcher('/(\$\w+)/i'), ['context' => ['*none', '*string.double']]),
-                'special'  => new Rule(new RegexMatcher('/(\$[#@_])/i'), ['context' => ['*none', '*string.double']]),
-                'argument' => new Rule(new RegexMatcher('/(\$\d+)/i'), ['context' => ['*none', '*string.double']]),
-                new Rule(new RegexMatcher('/\$\{(\w+)(.*?)\}/i', [ 1 => Token::NAME, 2 => 'string' ]), ['context' => ['*none', '*string.double']])
+                new Rule(new RegexMatcher('/(%\w+%)/i'), ['context' => ['*none', '*string.double']]),
+                new Rule(new RegexMatcher('/(%\w+)/i'), ['context' => ['*none', '*string.double']]),
             ],
 
             'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -48,7 +48,7 @@ class Batch extends GreedyLanguage
                     'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
                     'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
                     'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
-                    'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
+                    'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist', 'goto',
                 ]), ['priority' => 3]),
             ],
 

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Highlighter
+ *
+ * Copyright (C) 2016, Some right reserved.
+ *
+ * @author Kacper "Kadet" Donat <kacper@kadet.net>
+ *
+ * Contact with author:
+ * Xmpp: me@kadet.net
+ * E-mail: contact@kadet.net
+ *
+ * From Kadet with love.
+ */
+
+namespace Kadet\Highlighter\Language;
+
+use Kadet\Highlighter\Matcher\RegexMatcher;
+use Kadet\Highlighter\Matcher\WordMatcher;
+use Kadet\Highlighter\Parser\Rule;
+use Kadet\Highlighter\Parser\Token\LanguageToken;
+use Kadet\Highlighter\Parser\Token\Token;
+use Kadet\Highlighter\Parser\TokenFactory;
+use Kadet\Highlighter\Parser\Validator\Validator;
+
+class Batch extends GreedyLanguage
+{
+    public function setupRules()
+    {
+        $this->rules->addMany([
+//            'comment' => new Rule(new RegexMatcher('/^[ ]*(rem[^\r\n\w]*)/mi')),
+            'comment' => new Rule(new RegexMatcher('/^[ ]*(rem)( [ \w]*)?$/mi')),
+            'string' => CommonFeatures::strings(['single' => '\'', 'double' => '"']),
+
+            'keyword' => new Rule(new WordMatcher([
+                'ASSOC', 'ATTRIB', 'BREAK', 'BCDEDIT', 'CACLS', 'CD', 'CHCP', 'CHDIR', 'CHKDSK', 'CHKNTFS',
+                'CLS', 'CMD', 'COLOR', 'COMP', 'COMPACT', 'CONVERT', 'COPY', 'DATE', 'DEL', 'DIR', 'DISKCOMP',
+                'DISKCOPY', 'DISKPART', 'DOSKEY', 'DRIVERQUERY', 'ECHO', 'ENDLOCAL', 'ERASE', 'EXIT', 'FC',
+                'FIND', 'FINDSTR', 'FOR', 'FORMAT', 'FSUTIL', 'FTYPE', 'GPRESULT', 'GRAFTABL', 'HELP', 'ICACLS',
+                'IF', 'LABEL', 'MD', 'MKDIR', 'MKLINK', 'MODE', 'MORE', 'MOVE', 'OPENFILES', 'PATH', 'PAUSE',
+                'POPD', 'PRINT', 'PROMPT', 'PUSHD', 'RD', 'RECOVER', 'REN', 'RENAME', 'REPLACE', 'RMDIR',
+                'ROBOCOPY', 'SET', 'SETLOCAL', 'SC', 'SCHTASKS', 'SHIFT', 'SHUTDOWN',  'SORT', 'START',
+                'SUBST', 'SYSTEMINFO', 'TASKLIST', 'TASKKILL', 'TIME', 'TITLE', 'TREE', 'TYPE', 'VER',
+                'VERIFY', 'VOL', 'XCOPY', 'WMIC', 'CSCRIPT',
+                'echo', 'set', 'for', 'if', 'exit', 'else', 'do', 'not', 'defined', 'exist',
+            ]), ['priority' => 3]),
+
+            'variable'  => [
+                'assign' => new Rule(new RegexMatcher('/(\w+)[+-]?=/')),
+                new Rule(new RegexMatcher('/(\$\w+)/i'), ['context' => ['*none', '*string.double']]),
+                'special'  => new Rule(new RegexMatcher('/(\$[#@_])/i'), ['context' => ['*none', '*string.double']]),
+                'argument' => new Rule(new RegexMatcher('/(\$\d+)/i'), ['context' => ['*none', '*string.double']]),
+                new Rule(new RegexMatcher('/\$\{(\w+)(.*?)\}/i', [ 1 => Token::NAME, 2 => 'string' ]), ['context' => ['*none', '*string.double']])
+            ],
+
+            'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/')),
+            'delimiter' => new Rule(new RegexMatcher('/^(\$)/m')),
+
+            'expression' => [
+                new Rule(new RegexMatcher('/(?=(\$\(((?>[^$()]+|(?1))+)\)))/x'), [
+                    'context' => Validator::everywhere(),
+                    'factory' => new TokenFactory(LanguageToken::class),
+                    'inject'  => $this
+                ]),
+            ],
+
+            'operator.escape' => new Rule(new RegexMatcher('/(\\\(?:x[0-9a-fA-F]{1,2}|u\{[0-9a-fA-F]{1,6}\}|[0-7]{1,3}|.))/i'), [
+                'context' => ['*']
+            ]),
+        ]);
+    }
+
+    /**
+     * Unique language identifier, for example 'php'
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'batch';
+    }
+
+    public static function getMetadata()
+    {
+        return [
+            'name'      => ['bat', 'batch', 'dos'],
+            'mime'      => ['application/bat', 'application/x-bat', 'application/x-msdos-program'],
+            'extension' => ['*.bat', '*.cmd']
+        ];
+    }
+}

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -59,7 +59,6 @@ class Batch extends GreedyLanguage
             ],
 
             'number'    => new Rule(new RegexMatcher('/(-?(?:0[0-7]+|0[xX][0-9a-fA-F]+|0b[01]+|\d+))/', ['context' => '!comment'])),
-            'delimiter' => new Rule(new RegexMatcher('/^(\$)/m')),
 
             'symbol.parameter' => new Rule(new RegexMatcher('/(\/[a-z])\b/i'), [
                 'priority' => 0,

--- a/Language/Batch.php
+++ b/Language/Batch.php
@@ -22,9 +22,6 @@ use Kadet\Highlighter\Matcher\CommentMatcher;
 use Kadet\Highlighter\Matcher\RegexMatcher;
 use Kadet\Highlighter\Matcher\WordMatcher;
 use Kadet\Highlighter\Parser\Rule;
-use Kadet\Highlighter\Parser\Token\LanguageToken;
-use Kadet\Highlighter\Parser\TokenFactory;
-use Kadet\Highlighter\Parser\Validator\Validator;
 
 class Batch extends GreedyLanguage
 {
@@ -67,18 +64,6 @@ class Batch extends GreedyLanguage
             'symbol.parameter' => new Rule(new RegexMatcher('/(\/[a-z])\b/i'), [
                 'priority' => 0,
                 'context'  => ['!comment'],
-            ]),
-
-            'expression' => [
-                new Rule(new RegexMatcher('/(?=(\$\(((?>[^$()]+|(?1))+)\)))/x'), [
-                    'context' => Validator::everywhere(),
-                    'factory' => new TokenFactory(LanguageToken::class),
-                    'inject'  => $this
-                ]),
-            ],
-
-            'operator.escape' => new Rule(new RegexMatcher('/(\\\(?:x[0-9a-fA-F]{1,2}|u\{[0-9a-fA-F]{1,6}\}|[0-7]{1,3}|.))/i'), [
-                'context' => ['*']
             ]),
         ]);
     }

--- a/Tests/Expected/Test/batch/big.bat.tkn
+++ b/Tests/Expected/Test/batch/big.bat.tkn
@@ -1,6 +1,6 @@
 {language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
-rem  backbat.bat  -- Backup batch files (Windows NT/{number:Kadet\Highlighter\Parser\Token\Token}2000{/number:Kadet\Highlighter\Parser\Token\Token} version)
+rem  backbat.bat  -- Backup batch files (Windows NT/2000 version)
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
 rem  usage:  backbat backupdir
 {comment:Kadet\Highlighter\Parser\Token\Token}rem  where:  backupdir  is the directory to copy batch files{/comment:Kadet\Highlighter\Parser\Token\Token}
@@ -46,7 +46,7 @@ goto end
 {keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}\nul goto skipdir
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}md{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%errorlevel%{/variable:Kadet\Highlighter\Parser\Token\Token}"=="{number:Kadet\Highlighter\Parser\Token\Token}0{/number:Kadet\Highlighter\Parser\Token\Token}" goto skipdir
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%errorlevel%{/variable:Kadet\Highlighter\Parser\Token\Token}"=="0" goto skipdir
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}Error creating backup directory{/string:Kadet\Highlighter\Parser\Token\Token}
 goto end

--- a/Tests/Expected/Test/batch/big.bat.tkn
+++ b/Tests/Expected/Test/batch/big.bat.tkn
@@ -10,14 +10,14 @@ rem  usage:  backbat backupdir
 
 rem  Make sure that there is at least one argument
 
-{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}"=="" goto argsok
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}"=="" {keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} argsok
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}usage:  {variable:Kadet\Highlighter\Parser\Token\Token}%0{/variable:Kadet\Highlighter\Parser\Token\Token} backupdir{/string:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}where:  backupdir  is the directory to copy batch files{/string:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}                    {string:Kadet\Highlighter\Parser\Token\Token}all batch files in the current directory will{/string:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}                    {string:Kadet\Highlighter\Parser\Token\Token}be backed up{/string:Kadet\Highlighter\Parser\Token\Token}
 
-goto end
+{keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} end
 
 
 :argsok
@@ -33,23 +33,23 @@ goto end
 
 {comment:Kadet\Highlighter\Parser\Token\Token}rem  Check to make sure that the backupdir exists and isn't a file{/comment:Kadet\Highlighter\Parser\Token\Token}
 
-{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} goto notfile
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} notfile
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} is a file
-goto end
+{keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} end
 
 
 :notfile
 
 {comment:Kadet\Highlighter\Parser\Token\Token}rem  If the directory does not exist, create it.{/comment:Kadet\Highlighter\Parser\Token\Token}
 
-{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}\nul goto skipdir
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}\nul {keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} skipdir
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}md{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%errorlevel%{/variable:Kadet\Highlighter\Parser\Token\Token}"=="0" goto skipdir
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%errorlevel%{/variable:Kadet\Highlighter\Parser\Token\Token}"=="0" {keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} skipdir
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}Error creating backup directory{/string:Kadet\Highlighter\Parser\Token\Token}
-goto end
+{keyword:Kadet\Highlighter\Parser\Token\Token}goto{/keyword:Kadet\Highlighter\Parser\Token\Token} end
 
 
 :skipdir

--- a/Tests/Expected/Test/batch/big.bat.tkn
+++ b/Tests/Expected/Test/batch/big.bat.tkn
@@ -1,0 +1,73 @@
+{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
+rem  backbat.bat  -- Backup batch files (Windows NT/{number:Kadet\Highlighter\Parser\Token\Token}2000{/number:Kadet\Highlighter\Parser\Token\Token} version)
+{comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
+rem  usage:  backbat backupdir
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  where:  backupdir  is the directory to copy batch files{/comment:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem                     all batch files in the current directory will{/comment:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem                     be backed up{/comment:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+rem  Make sure that there is at least one argument
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}"=="" goto argsok
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}usage:  {variable:Kadet\Highlighter\Parser\Token\Token}%0{/variable:Kadet\Highlighter\Parser\Token\Token} backupdir{/string:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}where:  backupdir  is the directory to copy batch files{/string:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}                    {string:Kadet\Highlighter\Parser\Token\Token}all batch files in the current directory will{/string:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}                    {string:Kadet\Highlighter\Parser\Token\Token}be backed up{/string:Kadet\Highlighter\Parser\Token\Token}
+
+goto end
+
+
+:argsok
+
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}setlocal{/keyword:Kadet\Highlighter\Parser\Token\Token}
+
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Save the backup directory{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable.assign:Kadet\Highlighter\Parser\Token\Token}backupdir{/variable.assign:Kadet\Highlighter\Parser\Token\Token}={variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}
+
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Check to make sure that the backupdir exists and isn't a file{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} goto notfile
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} is a file
+goto end
+
+
+:notfile
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  If the directory does not exist, create it.{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}\nul goto skipdir
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}md{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} "{variable:Kadet\Highlighter\Parser\Token\Token}%errorlevel%{/variable:Kadet\Highlighter\Parser\Token\Token}"=="{number:Kadet\Highlighter\Parser\Token\Token}0{/number:Kadet\Highlighter\Parser\Token\Token}" goto skipdir
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}Error creating backup directory{/string:Kadet\Highlighter\Parser\Token\Token}
+goto end
+
+
+:skipdir
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Copy each batch file one at a time.{/comment:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Note:  the for loop variable (%%b) must be contain only one letter.{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}for{/keyword:Kadet\Highlighter\Parser\Token\Token} %{variable:Kadet\Highlighter\Parser\Token\Token}%b{/variable:Kadet\Highlighter\Parser\Token\Token} in ( *.bat ) {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}copy{/keyword:Kadet\Highlighter\Parser\Token\Token} %{variable:Kadet\Highlighter\Parser\Token\Token}%b{/variable:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token} > nul
+
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Use the for loop again to check if each file was copied (since it is{/comment:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  difficult to run multiple commands in a for loop).{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}for{/keyword:Kadet\Highlighter\Parser\Token\Token} %{variable:Kadet\Highlighter\Parser\Token\Token}%b{/variable:Kadet\Highlighter\Parser\Token\Token} in ( *.bat ) {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}if{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}exist{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%backupdir%{/variable:Kadet\Highlighter\Parser\Token\Token}\%{variable:Kadet\Highlighter\Parser\Token\Token}%b{/variable:Kadet\Highlighter\Parser\Token\Token} {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} %{variable:Kadet\Highlighter\Parser\Token\Token}%b{/variable:Kadet\Highlighter\Parser\Token\Token} was {keyword:Kadet\Highlighter\Parser\Token\Token}not{/keyword:Kadet\Highlighter\Parser\Token\Token} copied
+
+:end
+
+{comment:Kadet\Highlighter\Parser\Token\Token}rem  Clean up{/comment:Kadet\Highlighter\Parser\Token\Token}
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}endlocal{/keyword:Kadet\Highlighter\Parser\Token\Token}
+{/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -6,6 +6,6 @@ removeme To jest komentarz i nie ma wpływu na działanie programu
 autoremove Żaden nie wie iże jożech psem
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
 remąt
-{keyword.special:Kadet\Highlighter\Parser\Token\Token}echo{/keyword.special:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,4 +1,4 @@
-{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword.special:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword.special:Kadet\Highlighter\Parser\Token\Token}
+{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword:Kadet\Highlighter\Parser\Token\Token}
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Wartość dwóch parametrów przekazanych {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} skryptu
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -6,7 +6,7 @@
 
 {comment:Kadet\Highlighter\Parser\Token\Token}rem To jest komentarz i nie ma wpływu na działanie programu{/comment:Kadet\Highlighter\Parser\Token\Token}
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
+{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} {symbol.parameter:Kadet\Highlighter\Parser\Token\Token}/p{/symbol.parameter:Kadet\Highlighter\Parser\Token\Token} {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {comment:Kadet\Highlighter\Parser\Token\Token}:: Wyświetl odpowiedź użytkownika{/comment:Kadet\Highlighter\Parser\Token\Token}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -9,6 +9,7 @@
 {keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}
+{comment:Kadet\Highlighter\Parser\Token\Token}:: Wyświetl odpowiedź użytkownika{/comment:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, {variable:Kadet\Highlighter\Parser\Token\Token}%imie%{/variable:Kadet\Highlighter\Parser\Token\Token}.
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,11 +1,14 @@
 {language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword.special:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword.special:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Wartość dwóch parametrów przekazanych {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} skryptu
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} %{number:Kadet\Highlighter\Parser\Token\Token}1{/number:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} %{number:Kadet\Highlighter\Parser\Token\Token}2{/number:Kadet\Highlighter\Parser\Token\Token}
+
 {comment:Kadet\Highlighter\Parser\Token\Token}rem To jest komentarz i nie ma wpływu na działanie programu{/comment:Kadet\Highlighter\Parser\Token\Token}
-removeme To jest komentarz i nie ma wpływu na działanie programu
-{comment:Kadet\Highlighter\Parser\Token\Token}rem Żaden nie wie iże jożech psem{/comment:Kadet\Highlighter\Parser\Token\Token}
-autoremove Żaden nie wie iże jożech psem
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
-remąt
+{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
+
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,14 +1,14 @@
 {language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword.special:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword.special:Kadet\Highlighter\Parser\Token\Token}
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Wartość dwóch parametrów przekazanych {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} skryptu
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} %{number:Kadet\Highlighter\Parser\Token\Token}1{/number:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} %{number:Kadet\Highlighter\Parser\Token\Token}2{/number:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%2{/variable:Kadet\Highlighter\Parser\Token\Token}
 
 {comment:Kadet\Highlighter\Parser\Token\Token}rem To jest komentarz i nie ma wpływu na działanie programu{/comment:Kadet\Highlighter\Parser\Token\Token}
 {comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, {variable:Kadet\Highlighter\Parser\Token\Token}%imie%{/variable:Kadet\Highlighter\Parser\Token\Token}.
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,6 +1,6 @@
 {language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword:Kadet\Highlighter\Parser\Token\Token}
 
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Wartość dwóch parametrów przekazanych {keyword:Kadet\Highlighter\Parser\Token\Token}do{/keyword:Kadet\Highlighter\Parser\Token\Token} skryptu
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}Wartość dwóch parametrów przekazanych do skryptu{/string:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%1{/variable:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {variable:Kadet\Highlighter\Parser\Token\Token}%2{/variable:Kadet\Highlighter\Parser\Token\Token}
 
@@ -10,6 +10,6 @@
 
 {keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {comment:Kadet\Highlighter\Parser\Token\Token}:: Wyświetl odpowiedź użytkownika{/comment:Kadet\Highlighter\Parser\Token\Token}
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, {variable:Kadet\Highlighter\Parser\Token\Token}%imie%{/variable:Kadet\Highlighter\Parser\Token\Token}.
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} {string:Kadet\Highlighter\Parser\Token\Token}Witaj, {variable:Kadet\Highlighter\Parser\Token\Token}{variable:Kadet\Highlighter\Parser\Token\Token}%imie{/variable:Kadet\Highlighter\Parser\Token\Token}%{/variable:Kadet\Highlighter\Parser\Token\Token}.{/string:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,6 +1,11 @@
-{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}@{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} off
+{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}{keyword.special:Kadet\Highlighter\Parser\Token\Token}@echo off{/keyword.special:Kadet\Highlighter\Parser\Token\Token}
 {keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
-rem To jest komentarz i nie ma wpływu na działanie programu
-{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
+{comment:Kadet\Highlighter\Parser\Token\Token}rem To jest komentarz i nie ma wpływu na działanie programu{/comment:Kadet\Highlighter\Parser\Token\Token}
+removeme To jest komentarz i nie ma wpływu na działanie programu
+{comment:Kadet\Highlighter\Parser\Token\Token}rem Żaden nie wie iże jożech psem{/comment:Kadet\Highlighter\Parser\Token\Token}
+autoremove Żaden nie wie iże jożech psem
+{comment:Kadet\Highlighter\Parser\Token\Token}rem{/comment:Kadet\Highlighter\Parser\Token\Token}
+remąt
+{keyword.special:Kadet\Highlighter\Parser\Token\Token}echo{/keyword.special:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
 {keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
 {/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Expected/Test/batch/small.bat.tkn
+++ b/Tests/Expected/Test/batch/small.bat.tkn
@@ -1,0 +1,6 @@
+{language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}@{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} off
+{keyword:Kadet\Highlighter\Parser\Token\Token}set{/keyword:Kadet\Highlighter\Parser\Token\Token} /p {variable.assign:Kadet\Highlighter\Parser\Token\Token}imie{/variable.assign:Kadet\Highlighter\Parser\Token\Token}=Jak masz na imię?
+rem To jest komentarz i nie ma wpływu na działanie programu
+{keyword:Kadet\Highlighter\Parser\Token\Token}echo{/keyword:Kadet\Highlighter\Parser\Token\Token} Witaj, %imie%.
+{keyword:Kadet\Highlighter\Parser\Token\Token}pause{/keyword:Kadet\Highlighter\Parser\Token\Token}
+{/language.batch:Kadet\Highlighter\Parser\Token\LanguageToken}

--- a/Tests/Samples/batch/big.bat
+++ b/Tests/Samples/batch/big.bat
@@ -1,0 +1,72 @@
+@echo off
+rem
+rem  backbat.bat  -- Backup batch files (Windows NT/2000 version)
+rem
+rem  usage:  backbat backupdir
+rem  where:  backupdir  is the directory to copy batch files
+rem                     all batch files in the current directory will
+rem                     be backed up
+rem
+
+rem  Make sure that there is at least one argument
+
+if not "%1"=="" goto argsok
+
+echo usage:  %0 backupdir
+echo where:  backupdir  is the directory to copy batch files
+echo                    all batch files in the current directory will
+echo                    be backed up
+
+goto end
+
+
+:argsok
+
+
+setlocal
+
+
+rem  Save the backup directory
+
+set backupdir=%1
+
+
+rem  Check to make sure that the backupdir exists and isn't a file
+
+if not exist %backupdir% goto notfile
+
+echo %backupdir% is a file
+goto end
+
+
+:notfile
+
+rem  If the directory does not exist, create it.
+
+if exist %backupdir%\nul goto skipdir
+
+md %backupdir%
+if "%errorlevel%"=="0" goto skipdir
+
+echo Error creating backup directory
+goto end
+
+
+:skipdir
+
+rem  Copy each batch file one at a time.
+rem  Note:  the for loop variable (%%b) must be contain only one letter.
+
+for %%b in ( *.bat ) do copy %%b %backupdir% > nul
+
+
+rem  Use the for loop again to check if each file was copied (since it is
+rem  difficult to run multiple commands in a for loop).
+
+for %%b in ( *.bat ) do if not exist %backupdir%\%%b echo %%b was not copied
+
+:end
+
+rem  Clean up
+
+endlocal

--- a/Tests/Samples/batch/small.bat
+++ b/Tests/Samples/batch/small.bat
@@ -1,0 +1,10 @@
+@echo
+set /p imie=Jak masz na imię?
+rem To jest komentarz i nie ma wpływu na działanie programu
+removeme To jest komentarz i nie ma wpływu na działanie programu
+rem Żaden nie wie iże jożech psem
+autoremove Żaden nie wie iże jożech psem
+rem
+remąt
+echo Witaj, %imie%.
+pause

--- a/Tests/Samples/batch/small.bat
+++ b/Tests/Samples/batch/small.bat
@@ -1,4 +1,4 @@
-@echo
+@echo off
 set /p imie=Jak masz na imię?
 rem To jest komentarz i nie ma wpływu na działanie programu
 removeme To jest komentarz i nie ma wpływu na działanie programu

--- a/Tests/Samples/batch/small.bat
+++ b/Tests/Samples/batch/small.bat
@@ -1,10 +1,13 @@
 @echo off
-set /p imie=Jak masz na imię?
+
+echo Wartość dwóch parametrów przekazanych do skryptu
+echo %1
+echo %2
+
 rem To jest komentarz i nie ma wpływu na działanie programu
-removeme To jest komentarz i nie ma wpływu na działanie programu
-rem Żaden nie wie iże jożech psem
-autoremove Żaden nie wie iże jożech psem
 rem
-remąt
+set /p imie=Jak masz na imię?
+
+echo
 echo Witaj, %imie%.
 pause

--- a/Tests/Samples/batch/small.bat
+++ b/Tests/Samples/batch/small.bat
@@ -9,5 +9,6 @@ rem
 set /p imie=Jak masz na imię?
 
 echo
+:: Wyświetl odpowiedź użytkownika
 echo Witaj, %imie%.
 pause


### PR DESCRIPTION
This is one big of a ~~mess~~ draft. It's based off a https://github.com/kadet1090/KeyLighter/pull/56 and obviously it will have to be rebased but for now I kept the somehow-original commit history to make it easier to understand the ~~pain~~ process I was going through.

## Open questions

1. Do we have any support for tokenizing goto labels? From the quick grep of the codebase, I didn't spot anything like that. I think it could be nice but of course it's outside of the scope for this PR
2. I have a problem with matching variables. Batch allows two variants of syntax: `%foo%` and `%foo` - I have created two regex-based rules to match these. However, no matter how I set their priorities, `%foo%` always gets matched as "comment %foo" and then "comment %" (even though I use `\w+`). This can be seen in the token dump of `small.bat` or with the debug formatter
3. What is the `delimiter` rule used in Shell highlighting for?
4. For whatever reason I can't match just some of the comments in the `bit.batch`. This one really puzzles me tbh oO it can be seen from the token dump but lemme attach a screenshot to make it even more obvious

![image](https://github.com/kadet1090/KeyLighter/assets/1347533/53baf10b-e247-48f6-a6a9-e57f03a93fda)

pls send help